### PR TITLE
issue_#43-record-id

### DIFF
--- a/app/src/main/java/com/dirtfy/ppp/common/exception/RecordException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/RecordException.kt
@@ -4,6 +4,7 @@ sealed class RecordException(
     massage: String
 ): CustomException(massage) {
 
+    class IdLoss: RecordException("id is not found")
     class IssuedNameLoss: RecordException("issued name is not found")
     class IncomeLoss: RecordException("income is not found")
     class TypeLoss: RecordException("type is not found")

--- a/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
@@ -10,6 +10,8 @@ interface RecordApi {
     suspend fun readAll(): List<DataRecord>
     suspend fun readDetail(record: DataRecord): List<DataRecordDetail>
 
+    suspend fun getNextId(): Int
+
     fun recordStream(): Flow<List<DataRecord>>
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStorePath.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStorePath.kt
@@ -2,13 +2,14 @@ package com.dirtfy.ppp.data.api.impl.common.firebase
 
 object FireStorePath {
 
-    private const val CONSTANT: String = "constant"
+    private const val CONSTANT: String = "constant_exp"
 
     const val MAX_ACCOUNT_NUMBER: String = "$CONSTANT/MAX_ACCOUNT_NUMBER"
+    const val RECORD_ID_COUNT: String = "$CONSTANT/RECORD_ID_COUNT"
 
     const val ACCOUNT: String = "account_exp"
 
-    const val MENU: String = "menu"
+    const val MENU: String = "menu_exp"
 
     const val RECORD: String = "record_exp"
     const val RECORD_DETAIL: String = "detail"

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
@@ -13,7 +13,9 @@ import com.dirtfy.tagger.Tagger
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.AggregateField
 import com.google.firebase.firestore.AggregateSource
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.firestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.channels.awaitClose
@@ -40,17 +42,28 @@ class AccountFireStore @Inject constructor(): AccountApi, Tagger {
         return account
     }
 
+    private suspend fun getNextRecordId(): Int {
+        return Firebase.firestore.document(FireStorePath.RECORD_ID_COUNT).get().await()
+            .getLong("count")!!.toInt() + 1
+    }
+
     override suspend fun createRecord(
         accountNumber: Int,
         record: DataAccountRecord
     ): DataAccountRecord {
+        val nextRecordId = getNextRecordId()
+
         Firebase.firestore.runTransaction {
             val newRecord = recordRef.document()
 
             Log.d(TAG, "$record")
 
+            Firebase.firestore.document(FireStorePath.RECORD_ID_COUNT)
+                .update("count", FieldValue.increment(1))
+
             newRecord.set(
                 FireStoreRecord(
+                    id = nextRecordId,
                     timestamp = Timestamp(Date(record.timestamp)),
                     amount = record.difference,
                     type = accountNumber.toString(),

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
@@ -15,7 +15,6 @@ import com.google.firebase.firestore.AggregateField
 import com.google.firebase.firestore.AggregateSource
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.QuerySnapshot
-import com.google.firebase.firestore.firestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.channels.awaitClose

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/FireStoreRecord.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/FireStoreRecord.kt
@@ -8,6 +8,7 @@ import com.google.firebase.Timestamp
 import java.util.Date
 
 data class FireStoreRecord(
+    val id: Int?,
     val timestamp: Timestamp?,
     val amount: Int?,
     val type: String?,
@@ -18,11 +19,13 @@ data class FireStoreRecord(
         null,
         null,
         null,
+        null,
     )
 
     companion object {
         fun DataRecord.convertToFireStoreRecord(): FireStoreRecord {
             return FireStoreRecord(
+                id = id,
                 timestamp = Timestamp(Date(timestamp)),
                 amount = income,
                 type = type,
@@ -33,6 +36,7 @@ data class FireStoreRecord(
 
     fun convertToDataRecord(): DataRecord {
         return DataRecord(
+            id = id ?: throw RecordException.IdLoss(),
             income = amount ?: throw RecordException.IncomeLoss(),
             type = type?: throw RecordException.TypeLoss(),
             issuedBy = issuedName?: throw RecordException.IssuedNameLoss(),

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
@@ -14,7 +14,6 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.firestore
-import com.google.firebase.firestore.ktx.firestore
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
@@ -11,8 +11,10 @@ import com.dirtfy.ppp.data.dto.feature.record.DataRecordDetail
 import com.dirtfy.tagger.Tagger
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.firestore
+import com.google.firebase.firestore.ktx.firestore
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -31,6 +33,9 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
         Firebase.firestore.runTransaction {
             val newRecord = recordRef.document()
 
+            Firebase.firestore.document(FireStorePath.RECORD_ID_COUNT)
+                .update("count", FieldValue.increment(1))
+
             newRecord.set(
                 record.convertToFireStoreRecord()
             )
@@ -42,7 +47,9 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
             }
         }.await()
 
-        return record
+        val currentId = getNextId()-1
+
+        return record.copy(id = currentId)
     }
 
     override suspend fun readAll(): List<DataRecord> {
@@ -80,6 +87,11 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
             }.map { recordDetail ->
                 recordDetail.convertToDataRecordDetail()
             }
+    }
+
+    override suspend fun getNextId(): Int {
+        return Firebase.firestore.document(FireStorePath.RECORD_ID_COUNT).get().await()
+            .getLong("count")!!.toInt() + 1
     }
 
     override fun recordStream(): Flow<List<DataRecord>> = callbackFlow {

--- a/app/src/main/java/com/dirtfy/ppp/data/dto/feature/record/DataRecord.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/dto/feature/record/DataRecord.kt
@@ -3,6 +3,7 @@ package com.dirtfy.ppp.data.dto.feature.record
 import java.util.Calendar
 
 data class DataRecord(
+    val id: Int,
     val income: Int,
     val type: String,
     val issuedBy: String = "custom",

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
@@ -129,8 +129,11 @@ class TableBusinessLogic @Inject constructor(
 
         val orderList = tableApi.readAllOrder(group)
 
+        val nextRecordId = recordApi.getNextId()
+
         val payment = recordApi.create(
             record = DataRecord(
+                id = nextRecordId,
                 income = orderList.calcTotalPrice(),
                 type = DataRecordType.Cash.name
             ),
@@ -148,8 +151,11 @@ class TableBusinessLogic @Inject constructor(
 
         val orderList = tableApi.readAllOrder(group)
 
+        val nextRecordId = recordApi.getNextId()
+
         val payment = recordApi.create(
             record = DataRecord(
+                id = nextRecordId,
                 income = orderList.calcTotalPrice(),
                 type = DataRecordType.Card.name
             ),
@@ -169,8 +175,11 @@ class TableBusinessLogic @Inject constructor(
 
         val orderList = tableApi.readAllOrder(group)
 
+        val nextRecordId = recordApi.getNextId()
+
         val payment = recordApi.create(
             record = DataRecord(
+                id = nextRecordId,
                 income = -orderList.calcTotalPrice(),
                 type = accountNumber.toString(),
                 issuedBy = issuedName

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/common/converter/feature/record/RecordAtomConverter.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/common/converter/feature/record/RecordAtomConverter.kt
@@ -1,5 +1,6 @@
 package com.dirtfy.ppp.ui.controller.common.converter.feature.record
 
+import com.dirtfy.ppp.common.exception.RecordException
 import com.dirtfy.ppp.data.dto.feature.record.DataRecord
 import com.dirtfy.ppp.data.dto.feature.record.DataRecordDetail
 import com.dirtfy.ppp.data.dto.feature.record.DataRecordType
@@ -11,6 +12,7 @@ object RecordAtomConverter {
 
     fun DataRecord.convertToRawUiRecord(): UiRecord {
         return UiRecord(
+            id = id.toString(),
             timestamp = StringFormatConverter.formatTimestampFromMillis(timestamp),
             income = StringFormatConverter.formatCurrency(income),
             type = "$type - $issuedBy"
@@ -19,6 +21,7 @@ object RecordAtomConverter {
 
     fun DataRecord.convertToUiRecord(): UiRecord {
         return UiRecord(
+            id = id.toString(),
             timestamp = StringFormatConverter.formatTimestampFromMillis(timestamp),
             income = StringFormatConverter.formatCurrency(income),
             type = if (type == DataRecordType.Cash.name
@@ -42,6 +45,7 @@ object RecordAtomConverter {
 
     fun UiRecord.convertToDataRecord(): DataRecord {
         return DataRecord(
+            id = try { id.toInt() } catch (e: Exception) { throw RecordException.IdLoss() },
             income = StringFormatConverter.parseCurrency(income),
             type = type.split("-")[0],
             issuedBy = type.split("-")[1],
@@ -51,6 +55,7 @@ object RecordAtomConverter {
 
     fun UiRecord.convertToDataRecordFromRaw(): DataRecord {
         return DataRecord(
+            id = try { id.toInt() } catch (e: Exception) { throw RecordException.IdLoss() },
             income = StringFormatConverter.parseCurrency(income),
             type = type.split("-")[0],
             issuedBy = type.split("-")[1],

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordViewModel.kt
@@ -103,7 +103,7 @@ class RecordViewModel @Inject constructor(
     override fun updateNowRecord(record: UiRecord) {
         val rawValue = rawRecordListFlow.value.find {
             Log.d(TAG,"${it.timestamp} - ${record.timestamp}")
-            it.timestamp == record.timestamp
+            it.id == record.id
         }
         if(rawValue == null)
             nowRecordStateFlow.update {

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/atom/UiRecord.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/atom/UiRecord.kt
@@ -1,6 +1,7 @@
 package com.dirtfy.ppp.ui.state.feature.record.atom
 
 data class UiRecord(
+    val id: String = "",
     val timestamp: String = "",
     val income: String = "",
     val type: String = ""


### PR DESCRIPTION
DB:
record id constant 추가
menu 경로 변경 menu->menu_exp

Api:
account detail, record 데이터 생성시 record id count 읽어와서 id 추가, runTransaction block에서 시도 후 최종 record id로 id 적용
getNextId 함수 추가

data.dto:
id 데이터 추가

BusinessLogic:
pay 할 때 record id 추가

Controller:
RecordConverter에서 id 데이터 추가

ui.dto:
id 데이터 추가


