### PR TITLE
Integration of AccountControllers

### DIFF
--- a/app/src/main/java/com/dirtfy/ppp/common/di/AndroidViewModelModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/AndroidViewModelModule.kt
@@ -4,12 +4,6 @@ import android.content.Context
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.dirtfy.ppp.ui.controller.feature.account.AccountController
-import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
-import com.dirtfy.ppp.ui.controller.feature.account.AccountDetailController
-import com.dirtfy.ppp.ui.controller.feature.account.AccountUpdateController
-import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountCreateViewModel
-import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountDetailViewModel
-import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountUpdateViewModel
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountViewModel
 import com.dirtfy.ppp.ui.controller.feature.menu.MenuController
 import com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel.MenuViewModel
@@ -42,30 +36,6 @@ class AndroidViewModelModule {
         @ActivityContext context: Context
     ): AccountController {
         val viewModel = ViewModelProvider(context as ViewModelStoreOwner)[AccountViewModel::class.java]
-        return viewModel
-    }
-
-    @Provides
-    fun providesAccountCreateController(
-        @ActivityContext context: Context
-    ): AccountCreateController {
-        val viewModel = ViewModelProvider(context as ViewModelStoreOwner)[AccountCreateViewModel::class.java]
-        return viewModel
-    }
-
-    @Provides
-    fun providesAccountDetailController(
-        @ActivityContext context: Context
-    ): AccountDetailController {
-        val viewModel = ViewModelProvider(context as ViewModelStoreOwner)[AccountDetailViewModel::class.java]
-        return viewModel
-    }
-
-    @Provides
-    fun providesAccountUpdateController(
-        @ActivityContext context: Context
-    ): AccountUpdateController {
-        val viewModel = ViewModelProvider(context as ViewModelStoreOwner)[AccountUpdateViewModel::class.java]
         return viewModel
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/common/di/ControllerModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/ControllerModule.kt
@@ -1,5 +1,13 @@
 package com.dirtfy.ppp.common.di
 
+import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountDetailController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountListController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountUpdateController
+import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountCreateControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountDetailControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountListControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountUpdateControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.table.TableMenuController
 import com.dirtfy.ppp.ui.controller.feature.table.TableMergeController
 import com.dirtfy.ppp.ui.controller.feature.table.TableOrderController
@@ -28,4 +36,24 @@ abstract class ControllerModule {
     abstract fun bindsTableMenuController(
         controllerImpl: TableMenuControllerImpl
     ): TableMenuController
+
+    @Binds
+    abstract fun bindsAccountListController(
+        controllerImpl: AccountListControllerImpl
+    ): AccountListController
+
+    @Binds
+    abstract fun bindsAccountCreateController(
+        controllerImpl: AccountCreateControllerImpl
+    ): AccountCreateController
+
+    @Binds
+    abstract fun bindsAccountDetailController(
+        controllerImpl: AccountDetailControllerImpl
+    ): AccountDetailController
+
+    @Binds
+    abstract fun bindsAccountUpdateController(
+        controllerImpl: AccountUpdateControllerImpl
+    ): AccountUpdateController
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountController.kt
@@ -4,15 +4,27 @@ import com.dirtfy.ppp.ui.controller.common.Controller
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccountMode
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccountRecord
 
 interface AccountController
     : Controller<UiAccountScreenState, AccountController> {
 
     @Deprecated("screen state synchronized with repository")
     suspend fun updateAccountList()
+
+    suspend fun updateNewAccount(newAccountData: UiNewAccount)
+    suspend fun addAccount(newAccountData: UiNewAccount)
+    suspend fun setRandomValidAccountNumberToNewAccount()
+
+    suspend fun updateAccountRecordList()
+    fun updateNewAccountRecord(newAccountRecord: UiNewAccountRecord)
+    suspend fun addRecord(newAccountRecord: UiNewAccountRecord)
+
+    suspend fun updateAccount(newAccountData: UiNewAccount)
+
     fun updateNowAccount(account: UiAccount)
     fun updateSearchClue(clue: String)
-
     fun setMode(mode: UiAccountMode)
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountCreateController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountCreateController.kt
@@ -1,11 +1,11 @@
 package com.dirtfy.ppp.ui.controller.feature.account
 
-import com.dirtfy.ppp.ui.controller.common.Controller
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountCreateScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
+import kotlinx.coroutines.flow.Flow
 
-interface AccountCreateController
-    : Controller<UiAccountCreateScreenState, AccountCreateController> {
+interface AccountCreateController {
+    val screenData: Flow<UiAccountCreateScreenState>
 
     suspend fun updateNewAccount(newAccountData: UiNewAccount)
     suspend fun addAccount(newAccountData: UiNewAccount)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountDetailController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountDetailController.kt
@@ -1,16 +1,14 @@
 package com.dirtfy.ppp.ui.controller.feature.account
 
-import com.dirtfy.ppp.ui.controller.common.Controller
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountDetailScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccountRecord
+import kotlinx.coroutines.flow.Flow
 
-interface AccountDetailController
-    : Controller<UiAccountDetailScreenState, AccountDetailController> {
+interface AccountDetailController {
+    val screenData: Flow<UiAccountDetailScreenState>
 
-    @Deprecated("screen state synchronized with repository")
-    suspend fun updateAccountRecordList()
-    suspend fun updateNowAccount(account: UiAccount)
+    suspend fun updateAccountRecordList(account: UiAccount)
     fun updateNewAccountRecord(newAccountRecord: UiNewAccountRecord)
     suspend fun addRecord(newAccountRecord: UiNewAccountRecord)
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountListController.kt
@@ -1,0 +1,12 @@
+package com.dirtfy.ppp.ui.controller.feature.account
+
+import com.dirtfy.ppp.ui.state.feature.account.UiAccountListScreenState
+import kotlinx.coroutines.flow.Flow
+
+interface AccountListController {
+    val screenData: Flow<UiAccountListScreenState>
+
+    @Deprecated("screen state synchronized with repository")
+    suspend fun updateAccountList()
+    fun updateSearchClue(clue: String)
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountUpdateController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountUpdateController.kt
@@ -1,11 +1,11 @@
 package com.dirtfy.ppp.ui.controller.feature.account
 
-import com.dirtfy.ppp.ui.controller.common.Controller
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountUpdateScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
+import kotlinx.coroutines.flow.Flow
 
-interface AccountUpdateController
-    : Controller<UiAccountUpdateScreenState, AccountUpdateController> {
+interface AccountUpdateController {
+    val screenData: Flow<UiAccountUpdateScreenState>
 
     suspend fun updateAccount(newAccountData: UiNewAccount)
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountCreateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountCreateControllerImpl.kt
@@ -1,8 +1,6 @@
 package com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel
 
 import android.util.Log
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.dirtfy.ppp.data.logic.AccountBusinessLogic
 import com.dirtfy.ppp.ui.controller.common.converter.common.PhoneNumberFormatConverter.formatPhoneNumber
 import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
@@ -11,22 +9,19 @@ import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountCreateScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
 import com.dirtfy.tagger.Tagger
-import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class AccountCreateViewModel @Inject constructor(
+class AccountCreateControllerImpl @Inject constructor(
     private val accountBusinessLogic: AccountBusinessLogic
-): ViewModel(), AccountCreateController, Tagger {
+): AccountCreateController, Tagger {
 
     private val _screenData = MutableStateFlow(UiAccountCreateScreenState())
-    override val screenData: StateFlow<UiAccountCreateScreenState>
-        get() = _screenData
+    override val screenData: Flow<UiAccountCreateScreenState>
+        get() = _screenData // 안될거같음
 
     private fun _updateNewAccount(newAccountData: UiNewAccount) {
         _screenData.update {
@@ -87,9 +82,4 @@ class AccountCreateViewModel @Inject constructor(
             }
     }
 
-    override fun request(job: suspend AccountCreateController.() -> Unit) {
-        viewModelScope.launch {
-            job()
-        }
-    }
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountListControllerImpl.kt
@@ -1,0 +1,59 @@
+package com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel
+
+import com.dirtfy.ppp.data.logic.AccountBusinessLogic
+import com.dirtfy.ppp.ui.controller.common.converter.feature.account.AccountAtomConverter.convertToUiAccount
+import com.dirtfy.ppp.ui.controller.feature.account.AccountListController
+import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.common.UiState
+import com.dirtfy.ppp.ui.state.feature.account.UiAccountListScreenState
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+class AccountListControllerImpl @Inject constructor(
+    private val accountBusinessLogic: AccountBusinessLogic
+): AccountListController {
+
+    private val accountListFlow = accountBusinessLogic.accountStream()
+        .catch { cause ->
+            _screenData.update { it.copy(accountListState = UiScreenState(UiState.FAIL, cause.message)) }
+        }
+        .map { it.map { account -> account.convertToUiAccount() } }
+
+    private val _screenData: MutableStateFlow<UiAccountListScreenState>
+        = MutableStateFlow(UiAccountListScreenState())
+    override val screenData: Flow<UiAccountListScreenState>
+        = _screenData
+        .combine(accountListFlow) { state, accountList ->
+            val filteredAccountList = accountList.filter {
+                it.number.contains(state.searchClue)
+            }
+
+            var newState = state.copy(
+                accountList = filteredAccountList,
+            )
+
+            if (state.accountList != accountList // 내용이 달라졌을 때
+                || state.accountList !== accountList // 내용이 같지만 다른 인스턴스
+                || accountList == emptyList<UiAccount>()) // emptyList()는 항상 같은 인스턴스
+                newState = newState.copy(
+                    accountListState = UiScreenState(state = UiState.COMPLETE)
+                )
+
+            newState
+        }
+
+    @Deprecated("screen state synchronized with repository")
+    override suspend fun updateAccountList() {
+    }
+
+    override fun updateSearchClue(clue: String) {
+        _screenData.update { it.copy(searchClue = clue) }
+    }
+
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountListControllerImpl.kt
@@ -23,7 +23,7 @@ class AccountListControllerImpl @Inject constructor(
         .catch { cause ->
             _screenData.update { it.copy(accountListState = UiScreenState(UiState.FAIL, cause.message)) }
         }
-        .map { it.map { account -> account.convertToUiAccount() } }
+        .map { it.map { account -> account.convertToUiAccount(0) } }
 
     private val _screenData: MutableStateFlow<UiAccountListScreenState>
         = MutableStateFlow(UiAccountListScreenState())

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountUpdateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountUpdateControllerImpl.kt
@@ -1,8 +1,6 @@
 package com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel
 
 import android.util.Log
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.dirtfy.ppp.data.logic.AccountBusinessLogic
 import com.dirtfy.ppp.ui.controller.feature.account.AccountUpdateController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
@@ -10,22 +8,19 @@ import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountUpdateScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
 import com.dirtfy.tagger.Tagger
-import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class AccountUpdateViewModel @Inject constructor(
+class AccountUpdateControllerImpl @Inject constructor(
     private val accountBusinessLogic: AccountBusinessLogic
-): ViewModel(), AccountUpdateController, Tagger {
+): AccountUpdateController, Tagger {
 
     private val _screenData = MutableStateFlow(UiAccountUpdateScreenState())
-    override val screenData: StateFlow<UiAccountUpdateScreenState>
-        get() = _screenData
+    override val screenData: Flow<UiAccountUpdateScreenState>
+        get() = _screenData // 안될거같음
 
     override suspend fun updateAccount(newAccountData: UiNewAccount) {
         val (number, name, phoneNumber) = newAccountData
@@ -44,12 +39,6 @@ class AccountUpdateViewModel @Inject constructor(
             }
         }.collect {
             _screenData.update { it.copy(updateAccountState = UiScreenState(UiState.COMPLETE)) }
-        }
-    }
-
-    override fun request(job: suspend AccountUpdateController.() -> Unit) {
-        viewModelScope.launch {
-            job()
         }
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountViewModel.kt
@@ -1,25 +1,23 @@
 package com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dirtfy.ppp.data.logic.AccountBusinessLogic
-import com.dirtfy.ppp.ui.controller.common.converter.feature.account.AccountAtomConverter.convertToUiAccount
 import com.dirtfy.ppp.ui.controller.feature.account.AccountController
-import com.dirtfy.ppp.ui.state.common.UiScreenState
-import com.dirtfy.ppp.ui.state.common.UiState
+import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountDetailController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountListController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountUpdateController
 import com.dirtfy.ppp.ui.state.feature.account.UiAccountScreenState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccountMode
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccountRecord
 import com.dirtfy.tagger.Tagger
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -27,65 +25,46 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AccountViewModel @Inject constructor(
-    accountBusinessLogic: AccountBusinessLogic
+    private val accountListController: AccountListController,
+    private val accountCreateController: AccountCreateController,
+    private val accountDetailController: AccountDetailController,
+    private val accountUpdateController: AccountUpdateController
 ): ViewModel(), AccountController, Tagger {
 
-    private val accountList: Flow<List<UiAccount>>
-            = accountBusinessLogic.accountStream()
-        .map { it.map { account -> account.convertToUiAccount(0) } }
-
-    private val searchClueFlow = MutableStateFlow("")
-    private val modeFlow = MutableStateFlow(UiAccountMode.Main)
-    private val nowAccountFlow = MutableStateFlow(UiAccount())
-
+    private val _screenData: MutableStateFlow<UiAccountScreenState>
+        = MutableStateFlow(UiAccountScreenState())
     override val screenData: StateFlow<UiAccountScreenState>
-        = nowAccountFlow
-            .combine(searchClueFlow) { nowAccount, searchClue ->
-                UiAccountScreenState(
-                    nowAccount = nowAccount,
-                    searchClue = searchClue
-                )
-            }
-            .combine(modeFlow) { state, mode ->
-                state.copy(
-                    mode = mode
-                )
-            }
-            .combine(accountList) { state, accountList ->
-                val filteredAccountList = accountList.filter {
-                    it.number.contains(state.searchClue)
-                }
-
-                var newState = state.copy(
-                    accountList = filteredAccountList,
-                )
-
-                if (state.accountList != accountList /* 내용이 달라졌을 때 */
-                    || state.accountList !== accountList /* 내용이 같지만 다른 인스턴스 */
-                    || accountList == emptyList<UiAccount>() /* emptyList()는 항상 같은 인스턴스 */)
-                    newState = newState.copy(
-                        accountListState = UiScreenState(state = UiState.COMPLETE)
-                    )
-
-                newState
-            }
-            .catch { cause ->
-                Log.e(TAG, "uiAccountScreenState - combine failed \n ${cause.message}")
-
-                // TODO 더 기가 막힌 방법 생각해보기
-                UiAccountScreenState(
-                    searchClue = searchClueFlow.value,
-                    mode = modeFlow.value,
-                    nowAccount = nowAccountFlow.value,
-                    accountListState = UiScreenState(UiState.FAIL, cause.message)
-                )
-            }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = UiAccountScreenState()
+        = _screenData
+        .combine(accountListController.screenData) { state, listScreenData ->
+            state.copy(
+                accountList = listScreenData.accountList,
+                searchClue = listScreenData.searchClue,
+                accountListState = listScreenData.accountListState
             )
-
+        }.combine(accountCreateController.screenData) { state, createScreenData ->
+            state.copy(
+                newAccount = createScreenData.newAccount,
+                newAccountState = createScreenData.newAccountState,
+                numberGeneratingState = createScreenData.numberGeneratingState
+            )
+        }.combine(accountDetailController.screenData) { state, detailScreenData ->
+            state.copy(
+                nowAccount = detailScreenData.nowAccount,
+                newAccountRecord = detailScreenData.newAccountRecord,
+                accountRecordList = detailScreenData.accountRecordList,
+                accountRecordListState = detailScreenData.accountRecordListState,
+                newAccountRecordState = detailScreenData.newAccountRecordState
+            )
+        }.combine(accountUpdateController.screenData) { state, updateScreenData ->
+            state.copy(
+                updateAccount = updateScreenData.updateAccount,
+                updateAccountState = updateScreenData.updateAccountState
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UiAccountScreenState()
+        )
 
 
     @Deprecated("screen state synchronized with repository")
@@ -93,16 +72,44 @@ class AccountViewModel @Inject constructor(
         // TODO 다른 기기에서 어카운트 변경시 어떻게 뷰를 변경할 지 정해야 할 듯
     }
 
+    override suspend fun updateNewAccount(newAccountData: UiNewAccount) {
+        accountCreateController.updateNewAccount(newAccountData)
+    }
+
+    override suspend fun addAccount(newAccountData: UiNewAccount) {
+        accountCreateController.addAccount(newAccountData)
+    }
+
+    override suspend fun setRandomValidAccountNumberToNewAccount() {
+        accountCreateController.setRandomValidAccountNumberToNewAccount()
+    }
+
+    override suspend fun updateAccountRecordList() {
+        accountDetailController.updateAccountRecordList(_screenData.value.nowAccount)
+    }
+
     override fun updateNowAccount(account: UiAccount) {
-        nowAccountFlow.update { account }
+        _screenData.update { it.copy(nowAccount = account) }
+    }
+
+    override fun updateNewAccountRecord(newAccountRecord: UiNewAccountRecord) {
+        accountDetailController.updateNewAccountRecord(newAccountRecord)
+    }
+
+    override suspend fun addRecord(newAccountRecord: UiNewAccountRecord) {
+        accountDetailController.addRecord(newAccountRecord)
+    }
+
+    override suspend fun updateAccount(newAccountData: UiNewAccount) {
+        accountUpdateController.updateAccount(newAccountData)
     }
 
     override fun updateSearchClue(clue: String) {
-        searchClueFlow.update { clue }
+        accountListController.updateSearchClue(clue)
     }
 
     override fun setMode(mode: UiAccountMode) {
-        modeFlow.update { mode }
+        _screenData.update { it.copy(mode = mode) }
     }
 
     override fun request(job: suspend AccountController.() -> Unit) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountCreateScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountCreateScreenState.kt
@@ -7,5 +7,5 @@ import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
 data class UiAccountCreateScreenState(
     val newAccount: UiNewAccount = UiNewAccount(),
     val newAccountState: UiScreenState = UiScreenState(UiState.COMPLETE),
-    val numberGeneratingState: UiScreenState = UiScreenState()
+    val numberGeneratingState: UiScreenState = UiScreenState(UiState.COMPLETE)
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountListScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountListScreenState.kt
@@ -1,0 +1,11 @@
+package com.dirtfy.ppp.ui.state.feature.account
+
+import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
+
+data class UiAccountListScreenState(
+    val accountList: List<UiAccount> = emptyList(),
+    val searchClue: String = "",
+
+    val accountListState: UiScreenState = UiScreenState()
+)

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountScreenState.kt
@@ -1,14 +1,28 @@
 package com.dirtfy.ppp.ui.state.feature.account
 
 import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccountMode
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccountRecord
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccountRecord
+import com.dirtfy.ppp.ui.state.feature.account.atom.UiUpdateAccount
 
 data class UiAccountScreenState(
     val accountList: List<UiAccount> = emptyList(),
     val searchClue: String = "",
     val nowAccount: UiAccount = UiAccount(),
+    val newAccount: UiNewAccount = UiNewAccount(),
+    val newAccountRecord: UiNewAccountRecord = UiNewAccountRecord(),
+    val accountRecordList: List<UiAccountRecord> = emptyList(),
+    val updateAccount: UiUpdateAccount = UiUpdateAccount(),
     val mode: UiAccountMode = UiAccountMode.Main,
 
-    val accountListState: UiScreenState = UiScreenState()
+    val accountListState: UiScreenState = UiScreenState(),
+    val newAccountState: UiScreenState = UiScreenState(UiState.COMPLETE),
+    val numberGeneratingState: UiScreenState = UiScreenState(),
+    val accountRecordListState: UiScreenState = UiScreenState(),
+    val newAccountRecordState: UiScreenState = UiScreenState(UiState.COMPLETE),
+    val updateAccountState: UiScreenState = UiScreenState(UiState.COMPLETE),
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/account/UiAccountScreenState.kt
@@ -21,7 +21,7 @@ data class UiAccountScreenState(
 
     val accountListState: UiScreenState = UiScreenState(),
     val newAccountState: UiScreenState = UiScreenState(UiState.COMPLETE),
-    val numberGeneratingState: UiScreenState = UiScreenState(),
+    val numberGeneratingState: UiScreenState = UiScreenState(UiState.COMPLETE),
     val accountRecordListState: UiScreenState = UiScreenState(),
     val newAccountRecordState: UiScreenState = UiScreenState(UiState.COMPLETE),
     val updateAccountState: UiScreenState = UiScreenState(UiState.COMPLETE),

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountCreateScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountCreateScreen.kt
@@ -32,17 +32,17 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dirtfy.ppp.ui.controller.common.converter.common.PhoneNumberFormatConverter.formatPhoneNumber
-import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountController
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
 import javax.inject.Inject
 
 class AccountCreateScreen @Inject constructor(
-    val accountCreateController: AccountCreateController
+    val accountController: AccountController
 ) {
 
     @Composable
     fun Main(
-        controller: AccountCreateController = accountCreateController,
+        controller: AccountController = accountController,
         onAccountCreate: (UiNewAccount) -> Unit = {},
     ) {
         val screen by controller.screenData.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountDetailScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dirtfy.ppp.ui.controller.feature.account.AccountDetailController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
@@ -48,20 +48,18 @@ import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccountRecord
 import javax.inject.Inject
 
 class AccountDetailScreen @Inject constructor(
-    val accountDetailController: AccountDetailController
+    val accountController: AccountController
 ) {
 
     @Composable
     fun Main(
-        account: UiAccount,
-        controller: AccountDetailController = accountDetailController
+        controller: AccountController = accountController
     ) {
         val screen by controller.screenData.collectAsStateWithLifecycle()
 
         LaunchedEffect(key1 = controller) {
             controller.request {
-                updateNowAccount(account)
-                //updateAccountRecordList()
+                updateAccountRecordList()
             }
         }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountScreen.kt
@@ -244,7 +244,10 @@ class AccountScreen @Inject constructor(
                     ListItem(
                         modifier = Modifier
                             .clickable { onItemClick(account) }
-                            .background(MaterialTheme.colorScheme.surface, shape = RoundedCornerShape(8.dp)),
+                            .background(
+                                MaterialTheme.colorScheme.surface,
+                                shape = RoundedCornerShape(8.dp)
+                            ),
                         overlineContent = { Text(text = "ID : ${account.number}") },
                         headlineContent = { Text(text = account.name) },
                         supportingContent = { Text(text = account.phoneNumber) },
@@ -321,7 +324,7 @@ class AccountScreen @Inject constructor(
         onDismissRequest: () -> Unit
     ) { //TODO maxHeight 설정?
         Dialog(onDismissRequest = onDismissRequest) {
-            accountDetailScreen.Main(account = account)
+            accountDetailScreen.Main()
         }
     }
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountCreateScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountCreateScreen.kt
@@ -22,17 +22,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountController
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccount
 import javax.inject.Inject
 
 class AccountCreateScreen @Inject constructor(
-    val accountCreateController: AccountCreateController
+    val accountController: AccountController
 ){
 
     @Composable
     fun Main(
-        controller: AccountCreateController = accountCreateController,
+        controller: AccountController = accountController,
         onAccountCreate: (UiNewAccount) -> Unit = {},
     ) {
         val screen by controller.screenData.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountDetailScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dirtfy.ppp.ui.controller.feature.account.AccountDetailController
+import com.dirtfy.ppp.ui.controller.feature.account.AccountController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.account.atom.UiAccount
@@ -42,19 +42,18 @@ import com.dirtfy.ppp.ui.state.feature.account.atom.UiNewAccountRecord
 import javax.inject.Inject
 
 class AccountDetailScreen @Inject constructor(
-    val accountDetailController: AccountDetailController
+    val accountController: AccountController
 ) {
 
     @Composable
     fun Main(
-        account: UiAccount,
-        controller: AccountDetailController = accountDetailController
+        controller: AccountController = accountController
     ) {
         val screen by controller.screenData.collectAsStateWithLifecycle()
 
         LaunchedEffect(key1 = controller) {
             controller.request {
-                updateNowAccount(account)
+                updateAccountRecordList()
             }
         }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountScreen.kt
@@ -287,7 +287,7 @@ class AccountScreen @Inject constructor(
         onDismissRequest: () -> Unit
     ) { //TODO maxHeight 설정?
         Dialog(onDismissRequest = onDismissRequest) {
-            accountDetailScreen.Main(account = account)
+            accountDetailScreen.Main()
         }
     }
 }


### PR DESCRIPTION
#62 에서의 구조와 동일하게, Account Controller 의 구조를 변경했습니다.

최상위 컨트롤러 클래스인
AccountController <- AccountViewModel이 다음의 하위 클래스들을 사용합니다.

1. AccountListController - 화면에 출력되는 Account의 리스트를 관리
2. AccountCreateController - Account 생성 Dialog 전반을 관리
3. AccountDetailController - Account 하나에 대한 세부사항 Dialog 전반을 관리
4. AccountUpdateController - 특정 Account의 정보 수정에 관한 역할

최상위 클래스는 Android ViewModel 클래스이며, 나머지 하위 클래스들은 일반클래스입니다.