### PR TITLE
RecordControllers Reconstructed

### DIFF
--- a/app/src/main/java/com/dirtfy/ppp/common/di/AndroidViewModelModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/AndroidViewModelModule.kt
@@ -8,8 +8,6 @@ import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountViewMo
 import com.dirtfy.ppp.ui.controller.feature.menu.MenuController
 import com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel.MenuViewModel
 import com.dirtfy.ppp.ui.controller.feature.record.RecordController
-import com.dirtfy.ppp.ui.controller.feature.record.RecordDetailController
-import com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel.RecordDetailViewModel
 import com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel.RecordViewModel
 import com.dirtfy.ppp.ui.controller.feature.table.TableController
 import com.dirtfy.ppp.ui.controller.feature.table.impl.viewmodel.TableViewModel
@@ -44,14 +42,6 @@ class AndroidViewModelModule {
         @ActivityContext context: Context
     ): RecordController {
         val viewModel = ViewModelProvider(context as ViewModelStoreOwner)[RecordViewModel::class.java]
-        return viewModel
-    }
-
-    @Provides
-    fun providesRecordDetailController(
-        @ActivityContext context: Context
-    ): RecordDetailController {
-        val viewModel = ViewModelProvider(context as ViewModelStoreOwner)[RecordDetailViewModel::class.java]
         return viewModel
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/common/di/ControllerModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/ControllerModule.kt
@@ -8,6 +8,10 @@ import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountCreate
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountDetailControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountListControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountUpdateControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.record.RecordDetailController
+import com.dirtfy.ppp.ui.controller.feature.record.RecordListController
+import com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel.RecordDetailControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel.RecordListControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.table.TableMenuController
 import com.dirtfy.ppp.ui.controller.feature.table.TableMergeController
 import com.dirtfy.ppp.ui.controller.feature.table.TableOrderController
@@ -56,4 +60,14 @@ abstract class ControllerModule {
     abstract fun bindsAccountUpdateController(
         controllerImpl: AccountUpdateControllerImpl
     ): AccountUpdateController
+
+    @Binds
+    abstract fun bindsRecordListController(
+        controllerImpl: RecordListControllerImpl
+    ): RecordListController
+
+    @Binds
+    abstract fun bindsRecordDetailController(
+        controllerImpl: RecordDetailControllerImpl
+    ): RecordDetailController
 }

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/RecordException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/RecordException.kt
@@ -5,6 +5,7 @@ sealed class RecordException(
 ): CustomException(massage) {
 
     class IdLoss: RecordException("id is not found")
+    class IllegalIdAssignment: RecordException("id is already assigned (illegal)")
     class IssuedNameLoss: RecordException("issued name is not found")
     class IncomeLoss: RecordException("income is not found")
     class TypeLoss: RecordException("type is not found")

--- a/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 interface RecordApi {
 
     suspend fun create(record: DataRecord, detailList: List<DataRecordDetail>): DataRecord
+    suspend fun read(id: Int): DataRecord
     suspend fun readAll(): List<DataRecord>
     suspend fun <ValueType> readSumOf(key: String, value: ValueType, target:String): Int
     suspend fun readDetail(record: DataRecord): List<DataRecordDetail>

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
@@ -81,9 +81,9 @@ class AccountFireStore @Inject constructor(): AccountApi, Tagger {
     @Deprecated("moved to record api")
     override suspend fun readAccountBalance(accountNumber: Int): Int {
         val query = recordRef.whereEqualTo("type", "$accountNumber")
-        val aggregation = query.aggregate(AggregateField.sum("amount"))
+        val aggregation = query.aggregate(AggregateField.sum("income"))
         val result = aggregation.get(AggregateSource.SERVER).await()
-        val value = result.get(AggregateField.sum("amount"))
+        val value = result.get(AggregateField.sum("income"))
 
         Log.d(TAG, "$result\n$value")
 

--- a/app/src/main/java/com/dirtfy/ppp/data/dto/feature/record/DataRecord.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/dto/feature/record/DataRecord.kt
@@ -3,9 +3,13 @@ package com.dirtfy.ppp.data.dto.feature.record
 import java.util.Calendar
 
 data class DataRecord(
-    val id: Int,
+    val id: Int = ID_NOT_ASSIGNED,
     val income: Int,
     val type: String,
     val issuedBy: String = "custom",
     val timestamp: Long = Calendar.getInstance().timeInMillis
-)
+) {
+    companion object {
+        const val ID_NOT_ASSIGNED = -1
+    }
+}

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/AccountBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/AccountBusinessLogic.kt
@@ -107,10 +107,7 @@ class AccountBusinessLogic @Inject constructor(
         accountNumber: Int,
         accountRecord: DataAccountRecord
     ): DataAccountRecord {
-        val nextId = recordApi.getNextId()
-
         val record = DataRecord(
-            id = nextId,
             income = accountRecord.difference,
             type = accountNumber.toString(),
             issuedBy = accountRecord.issuedName

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/RecordBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/RecordBusinessLogic.kt
@@ -10,6 +10,10 @@ class RecordBusinessLogic @Inject constructor(
     private val repository: RecordApi
 ): BusinessLogic {
 
+    fun readRecord(id: Int) = operate {
+        repository.read(id)
+    }
+
     fun readRecords() = operate {
         val recordList = repository.readAll()
             .sortedBy { -it.timestamp }

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
@@ -10,14 +10,13 @@ import com.dirtfy.ppp.data.dto.feature.record.DataRecordDetail
 import com.dirtfy.ppp.data.dto.feature.record.DataRecordType
 import com.dirtfy.ppp.data.dto.feature.table.DataTableOrder
 import com.dirtfy.ppp.data.logic.common.BusinessLogic
-import com.dirtfy.tagger.Tagger
 import javax.inject.Inject
 
 class TableBusinessLogic @Inject constructor(
     private val accountApi: AccountApi,
     private val tableApi: TableApi,
     private val recordApi: RecordApi
-): BusinessLogic, Tagger {
+): BusinessLogic {
 
     private fun isInValidTableNumber(tableNumber: Int): Boolean {
         return tableNumber !in 1..11
@@ -168,21 +167,16 @@ class TableBusinessLogic @Inject constructor(
         accountNumber: Int,
         issuedName: String
     ) = operate {
-        Log.d(TAG, "Business - payTableWithPoint")
         val group = tableApi.readTable(tableNumber).group
 
         val orderList = tableApi.readAllOrder(group)
 
-        Log.d(TAG, "group, orderList gotten")
         val nowBalance = accountApi.readAccountBalance(accountNumber)
-        Log.d(TAG, "nowBalance $nowBalance")
         val totalPrice = orderList.calcTotalPrice()
-        Log.d(TAG, "totalPrice $totalPrice")
 
         if (nowBalance < totalPrice)
             throw TableException.InvalidPay()
 
-        Log.d(TAG, "recordApi create call")
         val payment = recordApi.create(
             record = DataRecord(
                 income = -totalPrice,
@@ -192,7 +186,7 @@ class TableBusinessLogic @Inject constructor(
             detailList = orderList.map{ it.convertToRecordDetail() }
         )
         // TODO 다른 DB간 transaction 처리
-        Log.d(TAG, "recordApi create called")
+
         cleanGroup(group)
         payment
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/common/converter/feature/record/RecordAtomConverter.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/common/converter/feature/record/RecordAtomConverter.kt
@@ -68,7 +68,7 @@ object RecordAtomConverter {
             id = id.toString(),
             timestamp = StringFormatConverter.formatTimestampFromMinute(timestamp),
             income = StringFormatConverter.formatCurrency(income),
-            type = if (type.split("-")[0].trim().matches(Regex("""^\d+$"""))) type
+            type = if (type.split("-")[0].trim().matches(Regex("""^\d+$"""))) "$type - $issuedBy"
                    else type.split("-")[0].trim()
         )
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/common/converter/feature/record/RecordAtomConverter.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/common/converter/feature/record/RecordAtomConverter.kt
@@ -47,8 +47,8 @@ object RecordAtomConverter {
         return DataRecord(
             id = try { id.toInt() } catch (e: Exception) { throw RecordException.IdLoss() },
             income = StringFormatConverter.parseCurrency(income),
-            type = type.split("-")[0],
-            issuedBy = type.split("-")[1],
+            type = type.split("-")[0].trim(),
+            issuedBy = type.split("-")[1].trim(),
             timestamp = StringFormatConverter.parseTimestampFromMillis(timestamp)
         )
     }
@@ -57,9 +57,31 @@ object RecordAtomConverter {
         return DataRecord(
             id = try { id.toInt() } catch (e: Exception) { throw RecordException.IdLoss() },
             income = StringFormatConverter.parseCurrency(income),
-            type = type.split("-")[0],
-            issuedBy = type.split("-")[1],
+            type = type.split("-")[0].trim(),
+            issuedBy = type.split("-")[1].trim(),
             timestamp = StringFormatConverter.parseTimestampFromMillis(timestamp)
+        )
+    }
+
+    fun DataRecord.convertToNowRecord(): UiRecord {
+        return UiRecord(
+            id = id.toString(),
+            timestamp = StringFormatConverter.formatTimestampFromMinute(timestamp),
+            income = StringFormatConverter.formatCurrency(income),
+            type = if (type.split("-")[0].trim().matches(Regex("""^\d+$"""))) type
+                   else type.split("-")[0].trim()
+        )
+    }
+
+    fun UiRecord.convertToDataRecordFromNowRecord(): DataRecord {
+        return DataRecord(
+            id = id.toInt(),
+            timestamp = StringFormatConverter.parseTimestampFromMinute(timestamp),
+            income = StringFormatConverter.parseCurrency(income),
+            type = if (type.split("-").size > 1) type.split("-")[0].trim()
+                   else type,
+            issuedBy = if (type.split("-").size > 1) type.split("-")[1].trim()
+                       else "custom"
         )
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountCreateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountCreateControllerImpl.kt
@@ -21,7 +21,7 @@ class AccountCreateControllerImpl @Inject constructor(
 
     private val _screenData = MutableStateFlow(UiAccountCreateScreenState())
     override val screenData: Flow<UiAccountCreateScreenState>
-        get() = _screenData // 안될거같음
+        get() = _screenData
 
     private fun _updateNewAccount(newAccountData: UiNewAccount) {
         _screenData.update {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountDetailControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountDetailControllerImpl.kt
@@ -31,7 +31,7 @@ class AccountDetailControllerImpl @Inject constructor(
         )
     )
     override val screenData: Flow<UiAccountDetailScreenState>
-        get() = _screenData // 안될거같음
+        get() = _screenData
 
     private lateinit var accountRecordListStream: Flow<List<UiAccountRecord>>
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountDetailControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountDetailControllerImpl.kt
@@ -62,7 +62,11 @@ class AccountDetailControllerImpl @Inject constructor(
                 _screenData.update { before ->
                     before.copy(
                         nowAccount = account.copy(
-                            balance = listUiRecord.sumOf { uiRecord -> StringFormatConverter.parseCurrency(uiRecord.difference) }.toString()
+                            balance = StringFormatConverter.formatCurrency(
+                                listUiRecord.sumOf { uiRecord ->
+                                    StringFormatConverter.parseCurrency(uiRecord.difference)
+                                }
+                            )
                         ),
                         accountRecordList = listUiRecord,
                         accountRecordListState = UiScreenState(UiState.COMPLETE)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountUpdateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountUpdateControllerImpl.kt
@@ -20,7 +20,7 @@ class AccountUpdateControllerImpl @Inject constructor(
 
     private val _screenData = MutableStateFlow(UiAccountUpdateScreenState())
     override val screenData: Flow<UiAccountUpdateScreenState>
-        get() = _screenData // 안될거같음
+        get() = _screenData
 
     override suspend fun updateAccount(newAccountData: UiNewAccount) {
         val (number, name, phoneNumber) = newAccountData

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordController.kt
@@ -9,6 +9,7 @@ interface RecordController: Controller<UiRecordScreenState, RecordController> {
 
     @Deprecated("screen state synchronized with repository")
     suspend fun updateRecordList()
+    suspend fun updateRecordDetailList()
     fun updateSearchClue(clue: String)
     fun updateNowRecord(record: UiRecord)
     fun setMode(mode: UiRecordMode)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordController.kt
@@ -11,7 +11,7 @@ interface RecordController: Controller<UiRecordScreenState, RecordController> {
     suspend fun updateRecordList()
     suspend fun updateRecordDetailList()
     fun updateSearchClue(clue: String)
-    fun updateNowRecord(record: UiRecord)
+    suspend fun updateNowRecord(record: UiRecord)
     fun setMode(mode: UiRecordMode)
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordDetailController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordDetailController.kt
@@ -1,13 +1,14 @@
 package com.dirtfy.ppp.ui.controller.feature.record
 
-import com.dirtfy.ppp.ui.controller.common.Controller
 import com.dirtfy.ppp.ui.state.feature.record.UiRecordDetailScreenState
 import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
+import kotlinx.coroutines.flow.Flow
 
-interface RecordDetailController
-    : Controller<UiRecordDetailScreenState, RecordDetailController> {
+interface RecordDetailController {
 
-    suspend fun updateRecordDetailList(record: UiRecord)
-    suspend fun updateNowRecord(record: UiRecord)
+    val screenData: Flow<UiRecordDetailScreenState>
+
+    suspend fun updateRecordDetailList()
+    fun updateNowRecord(record: UiRecord)
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordDetailController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordDetailController.kt
@@ -9,6 +9,6 @@ interface RecordDetailController {
     val screenData: Flow<UiRecordDetailScreenState>
 
     suspend fun updateRecordDetailList()
-    fun updateNowRecord(record: UiRecord)
+    suspend fun updateNowRecord(record: UiRecord)
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordListController.kt
@@ -1,0 +1,14 @@
+package com.dirtfy.ppp.ui.controller.feature.record
+
+import com.dirtfy.ppp.ui.state.feature.record.UiRecordListScreenState
+import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
+import kotlinx.coroutines.flow.Flow
+
+interface RecordListController {
+    val screenData: Flow<UiRecordListScreenState>
+
+    @Deprecated("screen state synchronized with repository")
+    suspend fun updateRecordList()
+    fun updateSearchClue(clue: String)
+    fun findRawRecord(record: UiRecord): UiRecord?
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/RecordListController.kt
@@ -1,7 +1,6 @@
 package com.dirtfy.ppp.ui.controller.feature.record
 
 import com.dirtfy.ppp.ui.state.feature.record.UiRecordListScreenState
-import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
 import kotlinx.coroutines.flow.Flow
 
 interface RecordListController {
@@ -10,5 +9,4 @@ interface RecordListController {
     @Deprecated("screen state synchronized with repository")
     suspend fun updateRecordList()
     fun updateSearchClue(clue: String)
-    fun findRawRecord(record: UiRecord): UiRecord?
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordDetailControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordDetailControllerImpl.kt
@@ -1,9 +1,6 @@
 package com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel
 
 import android.util.Log
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.dirtfy.ppp.data.dto.feature.record.DataRecordType
 import com.dirtfy.ppp.data.logic.RecordBusinessLogic
 import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToDataRecordFromRaw
 import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToUiRecordDetail
@@ -13,28 +10,27 @@ import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.record.UiRecordDetailScreenState
 import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
 import com.dirtfy.tagger.Tagger
-import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class RecordDetailViewModel @Inject constructor(
+class RecordDetailControllerImpl @Inject constructor(
     private val recordBusinessLogic: RecordBusinessLogic
-): ViewModel(), RecordDetailController, Tagger {
+): RecordDetailController, Tagger {
+
+    private lateinit var rawNowRecord: UiRecord
 
     private val _screenData = MutableStateFlow(UiRecordDetailScreenState())
-    override val screenData: StateFlow<UiRecordDetailScreenState>
+    override val screenData: Flow<UiRecordDetailScreenState>
         get() = _screenData
 
     private suspend fun _updateRecordDetailList(record: UiRecord) {
         Log.d(TAG, "$record")
         Log.d(TAG, "${record.convertToDataRecordFromRaw()}")
-        
+
         _screenData.update { it.copy(recordDetailListState = UiScreenState(UiState.LOADING)) }
         
         recordBusinessLogic.readRecordDetail(record.convertToDataRecordFromRaw())
@@ -56,28 +52,15 @@ class RecordDetailViewModel @Inject constructor(
             }
     }
 
-    override suspend fun updateRecordDetailList(record: UiRecord) {
-        _updateRecordDetailList(record)
+    override suspend fun updateRecordDetailList() {
+        _updateRecordDetailList(rawNowRecord)
     }
 
-    override suspend fun updateNowRecord(record: UiRecord) {
-        // TODO 의문 밖에 들지 않는 로직
-        val type = record.type.split("-")[0].trim()
-        var newValue = if (type == DataRecordType.Card.name ||
-            type == DataRecordType.Cash.name) {
-            record.copy(type = type)
-        } else {
-            record
-        }
-        newValue = newValue.copy(timestamp = newValue.timestamp.substring(0, 16))
+    override fun updateNowRecord(record: UiRecord) {
+        rawNowRecord = record
+        val newValue = record.copy(timestamp = record.timestamp.substring(0, 16))
 
         _screenData.update { it.copy(nowRecord = newValue) }
-        _updateRecordDetailList(record)
     }
 
-    override fun request(job: suspend RecordDetailController.() -> Unit) {
-        viewModelScope.launch {
-            job()
-        }
-    }
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordListControllerImpl.kt
@@ -1,7 +1,6 @@
 package com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel
 
 import com.dirtfy.ppp.data.logic.RecordBusinessLogic
-import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToRawUiRecord
 import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToUiRecord
 import com.dirtfy.ppp.ui.controller.feature.record.RecordListController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
@@ -23,11 +22,8 @@ class RecordListControllerImpl @Inject constructor(
     private val _screenData: MutableStateFlow<UiRecordListScreenState>
             = MutableStateFlow(UiRecordListScreenState())
 
-    private lateinit var rawRecordList: List<UiRecord>
-
     private val recordListFlow = recordBusinessLogic.recordStream()
         .map {
-            rawRecordList = it.map { data -> data.convertToRawUiRecord() }
             it.map { data -> data.convertToUiRecord() }
         }
         .catch { cause ->
@@ -65,10 +61,4 @@ class RecordListControllerImpl @Inject constructor(
         _screenData.update { it.copy(searchClue = clue) }
     }
 
-    override fun findRawRecord(record: UiRecord): UiRecord? {
-        val rawValue = rawRecordList.find {
-            it.id == record.id
-        }
-        return rawValue
-    }
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordListControllerImpl.kt
@@ -1,0 +1,74 @@
+package com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel
+
+import com.dirtfy.ppp.data.logic.RecordBusinessLogic
+import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToRawUiRecord
+import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToUiRecord
+import com.dirtfy.ppp.ui.controller.feature.record.RecordListController
+import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.common.UiState
+import com.dirtfy.ppp.ui.state.feature.record.UiRecordListScreenState
+import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+class RecordListControllerImpl @Inject constructor(
+    private val recordBusinessLogic: RecordBusinessLogic
+): RecordListController {
+
+    private val _screenData: MutableStateFlow<UiRecordListScreenState>
+            = MutableStateFlow(UiRecordListScreenState())
+
+    private lateinit var rawRecordList: List<UiRecord>
+
+    private val recordListFlow = recordBusinessLogic.recordStream()
+        .map {
+            rawRecordList = it.map { data -> data.convertToRawUiRecord() }
+            it.map { data -> data.convertToUiRecord() }
+        }
+        .catch { cause ->
+            _screenData.update { it.copy(recordListState = UiScreenState(UiState.FAIL, cause.message)) }
+        }
+
+    override val screenData: Flow<UiRecordListScreenState>
+        = _screenData
+        .combine(recordListFlow) { state, recordList ->
+            // TODO searchClue 구현되면 여기서 filtering
+            /*val filteredAccountList = recordList.filter {
+                it.number.contains(state.searchClue)
+            }
+            var newState = state.copy(
+                accountList = filteredAccountList,
+            )*/
+            var newState = state.copy(
+                recordList = recordList
+            )
+            if (state.recordList != recordList // 내용이 달라졌을 때
+                || state.recordList !== recordList // 내용이 같지만 다른 인스턴스
+                || recordList == emptyList<UiRecord>()) // emptyList()는 항상 같은 인스턴스
+                newState = newState.copy(
+                    recordListState = UiScreenState(state = UiState.COMPLETE)
+                )
+
+            newState
+        }
+
+    @Deprecated("screen state synchronized with repository")
+    override suspend fun updateRecordList() {
+    }
+
+    override fun updateSearchClue(clue: String) {
+        _screenData.update { it.copy(searchClue = clue) }
+    }
+
+    override fun findRawRecord(record: UiRecord): UiRecord? {
+        val rawValue = rawRecordList.find {
+            it.id == record.id
+        }
+        return rawValue
+    }
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/record/impl/viewmodel/RecordViewModel.kt
@@ -1,13 +1,11 @@
 package com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dirtfy.ppp.common.exception.RecordException
-import com.dirtfy.ppp.data.logic.RecordBusinessLogic
-import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToRawUiRecord
-import com.dirtfy.ppp.ui.controller.common.converter.feature.record.RecordAtomConverter.convertToUiRecord
 import com.dirtfy.ppp.ui.controller.feature.record.RecordController
+import com.dirtfy.ppp.ui.controller.feature.record.RecordDetailController
+import com.dirtfy.ppp.ui.controller.feature.record.RecordListController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.record.UiRecordScreenState
@@ -18,9 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -28,63 +24,31 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RecordViewModel @Inject constructor(
-    recordBusinessLogic: RecordBusinessLogic
+    private val listController: RecordListController,
+    private val detailController: RecordDetailController
 ): ViewModel(), RecordController, Tagger {
 
-    private val searchClueFlow = MutableStateFlow("")
-    private val nowRecordFlow = MutableStateFlow(UiRecord())
     private val modeFlow = MutableStateFlow(UiRecordMode.Main)
-    private val rawRecordListFlow = MutableStateFlow(emptyList<UiRecord>())
     private val nowRecordStateFlow = MutableStateFlow(UiScreenState(UiState.COMPLETE))
 
-    private val recordStream = recordBusinessLogic.recordStream()
-        .map {
-            rawRecordListFlow.value = it.map { data -> data.convertToRawUiRecord() }
-            it.map { data -> data.convertToUiRecord() }
-        }
-
     override val screenData: StateFlow<UiRecordScreenState>
-        = searchClueFlow
-            .combine(modeFlow) { searchClue, mode ->
+        = modeFlow
+            .combine(nowRecordStateFlow) { mode, nowRecordState ->
                 UiRecordScreenState(
-                    searchClue = searchClue,
-                    mode = mode
-                )
-            }.combine(nowRecordFlow) { state, nowRecord ->
-                state.copy(
-                    nowRecord = nowRecord
-                )
-            }.combine(nowRecordStateFlow) { state, nowRecordState ->
-                state.copy(
+                    mode = mode,
                     nowRecordState = nowRecordState
                 )
-            }.combine(recordStream) { state, recordList ->
-                // TODO searchClue 구현되면 여기서 filtering
-                /*val filteredAccountList = recordList.filter {
-                    it.number.contains(state.searchClue)
-                }
-                var newState = state.copy(
-                    accountList = filteredAccountList,
-                )*/
-                var newState = state.copy(
-                    recordList = recordList
+            }.combine(listController.screenData) { state, listScreenData ->
+                state.copy(
+                    recordList = listScreenData.recordList,
+                    searchClue = listScreenData.searchClue,
+                    recordListState = listScreenData.recordListState
                 )
-                if (state.recordList != recordList /* 내용이 달라졌을 때 */
-                    || state.recordList !== recordList /* 내용이 같지만 다른 인스턴스 */
-                    || recordList == emptyList<UiRecord>() /* emptyList()는 항상 같은 인스턴스 */)
-                    newState = newState.copy(
-                        recordListState = UiScreenState(state = UiState.COMPLETE)
-                    )
-
-                newState
-            }.catch { cause ->
-                // TODO 더 기가 막힌 방법 생각해보기
-                UiRecordScreenState(
-                    searchClue = searchClueFlow.value,
-                    mode = modeFlow.value,
-                    nowRecord = nowRecordFlow.value,
-                    nowRecordState = nowRecordStateFlow.value,
-                    recordListState = UiScreenState(UiState.FAIL, cause.message)
+            }.combine(detailController.screenData) { state, detailScreenData ->
+                state.copy(
+                    recordDetailList = detailScreenData.recordDetailList,
+                    nowRecord = detailScreenData.nowRecord,
+                    recordDetailListState = detailScreenData.recordDetailListState
                 )
             }.stateIn(
                 scope = viewModelScope,
@@ -96,22 +60,23 @@ class RecordViewModel @Inject constructor(
     override suspend fun updateRecordList() {
     }
 
+    override suspend fun updateRecordDetailList() {
+        detailController.updateRecordDetailList()
+    }
+
     override fun updateSearchClue(clue: String) {
-        searchClueFlow.update { clue }
+        listController.updateSearchClue(clue)
     }
 
     override fun updateNowRecord(record: UiRecord) {
-        val rawValue = rawRecordListFlow.value.find {
-            Log.d(TAG,"${it.timestamp} - ${record.timestamp}")
-            it.id == record.id
-        }
+        val rawValue = listController.findRawRecord(record)
         if(rawValue == null)
             nowRecordStateFlow.update {
                 // TODO 이거 에러 처리 하는 부분 뷰 레이어에 필요함.
                 UiScreenState(UiState.FAIL, RecordException.NonExistQuery().message)
             }
         else {
-            nowRecordFlow.update { rawValue } // TODO issued name 어떻게 주지?
+            detailController.updateNowRecord(rawValue)
             nowRecordStateFlow.update { UiScreenState(UiState.COMPLETE) }
         }
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/UiRecordDetailScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/UiRecordDetailScreenState.kt
@@ -8,5 +8,6 @@ data class UiRecordDetailScreenState(
     val recordDetailList: List<UiRecordDetail> = emptyList(),
     val nowRecord: UiRecord = UiRecord(),
 
+    val nowRecordState: UiScreenState = UiScreenState(),
     val recordDetailListState: UiScreenState = UiScreenState()
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/UiRecordListScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/UiRecordListScreenState.kt
@@ -1,0 +1,11 @@
+package com.dirtfy.ppp.ui.state.feature.record
+
+import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
+
+data class UiRecordListScreenState(
+    val recordList: List<UiRecord> = emptyList(),
+    val searchClue: String = "",
+
+    val recordListState: UiScreenState = UiScreenState(),
+)

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/UiRecordScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/record/UiRecordScreenState.kt
@@ -3,14 +3,17 @@ package com.dirtfy.ppp.ui.state.feature.record
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
+import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecordDetail
 import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecordMode
 
 data class UiRecordScreenState(
     val recordList: List<UiRecord> = emptyList(),
+    val recordDetailList: List<UiRecordDetail> = emptyList(),
     val searchClue: String = "",
     val nowRecord: UiRecord = UiRecord(),
     val mode: UiRecordMode = UiRecordMode.Main,
 
     val recordListState: UiScreenState = UiScreenState(),
-    val nowRecordState: UiScreenState = UiScreenState(UiState.COMPLETE)
+    val recordDetailListState: UiScreenState = UiScreenState(),
+    val nowRecordState: UiScreenState = UiScreenState(UiState.COMPLETE),
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountScreen.kt
@@ -146,7 +146,6 @@ class AccountScreen @Inject constructor(
                 }
                 UiAccountMode.Detail -> {
                     AccountDetailDialog(
-                        account = nowAccount,
                         onDismissRequest = onDismissRequest
                     )
                 }
@@ -320,7 +319,6 @@ class AccountScreen @Inject constructor(
 
     @Composable
     fun AccountDetailDialog(
-        account: UiAccount,
         onDismissRequest: () -> Unit
     ) { //TODO maxHeight 설정?
         Dialog(onDismissRequest = onDismissRequest) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,11 +41,11 @@ class RecordDetailScreen @Inject constructor(
     ) {
         val screenData by controller.screenData.collectAsStateWithLifecycle()
 
-        LaunchedEffect(key1 = controller) {
-            controller.run {
-                updateRecordDetailList()
-            }
-        }
+//        LaunchedEffect(key1 = controller) {
+//            controller.run {
+//                updateRecordDetailList()
+//            }
+//        }
 
         ScreenContent(
             nowRecord = screenData.nowRecord,

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordDetailScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dirtfy.ppp.ui.controller.feature.record.RecordDetailController
+import com.dirtfy.ppp.ui.controller.feature.record.RecordController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
@@ -33,20 +33,18 @@ import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecordDetail
 import javax.inject.Inject
 
 class RecordDetailScreen @Inject constructor(
-    val recordDetailController: RecordDetailController
+    val recordController: RecordController
 ) {
 
     @Composable
     fun Main(
-        firstRecord: UiRecord,
-        controller: RecordDetailController = recordDetailController
+        controller: RecordController = recordController
     ) {
         val screenData by controller.screenData.collectAsStateWithLifecycle()
 
         LaunchedEffect(key1 = controller) {
             controller.run {
-                updateRecordDetailList(firstRecord)
-                updateNowRecord(firstRecord)
+                updateRecordDetailList()
             }
         }
 
@@ -55,7 +53,7 @@ class RecordDetailScreen @Inject constructor(
             recordDetailList = screenData.recordDetailList,
             recordDetailListState = screenData.recordDetailListState,
             onRetryClick = {
-                controller.request { updateRecordDetailList(screenData.nowRecord) }
+                controller.request { updateRecordDetailList() }
             }
         )
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordScreen.kt
@@ -49,9 +49,10 @@ class RecordScreen @Inject constructor(
             mode = screenData.mode,
             onClueChanged = { controller.updateSearchClue(it) },
             onItemClick = {
-                controller.run{
-                    updateNowRecord(it)
+                controller.request{
                     setMode(UiRecordMode.Detail)
+                    updateNowRecord(it)
+                    updateRecordDetailList()
                 }
             },
             onDismissRequest = {

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordScreen.kt
@@ -93,7 +93,6 @@ class RecordScreen @Inject constructor(
             when(mode) {
                 UiRecordMode.Detail -> {
                     RecordDetailDialog(
-                        nowAccount = nowRecord,
                         onDismissRequest = onDismissRequest
                     )
                 }
@@ -177,11 +176,10 @@ class RecordScreen @Inject constructor(
 
     @Composable
     fun RecordDetailDialog(
-        nowAccount: UiRecord,
         onDismissRequest: () -> Unit
     ) {
         Dialog(onDismissRequest = onDismissRequest) {
-            recordDetailScreen.Main(firstRecord = nowAccount)
+            recordDetailScreen.Main()
         }
     }
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountScreen.kt
@@ -138,7 +138,6 @@ class AccountScreen @Inject constructor(
                 }
                 UiAccountMode.Detail -> {
                     AccountDetailDialog(
-                        account = nowAccount,
                         onDismissRequest = onDismissRequest
                     )
                 }
@@ -283,7 +282,6 @@ class AccountScreen @Inject constructor(
 
     @Composable
     fun AccountDetailDialog(
-        account: UiAccount,
         onDismissRequest: () -> Unit
     ) { //TODO maxHeight 설정?
         Dialog(onDismissRequest = onDismissRequest) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,11 +41,11 @@ class RecordDetailScreen @Inject constructor(
     ) {
         val screenData by controller.screenData.collectAsStateWithLifecycle()
 
-        LaunchedEffect(key1 = controller) {
-            controller.run {
-                updateRecordDetailList()
-            }
-        }
+//        LaunchedEffect(key1 = controller) {
+//            controller.run {
+//                updateRecordDetailList()
+//            }
+//        }
 
         ScreenContent(
             nowRecord = screenData.nowRecord,

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordDetailScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dirtfy.ppp.ui.controller.feature.record.RecordDetailController
+import com.dirtfy.ppp.ui.controller.feature.record.RecordController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecord
@@ -33,20 +33,18 @@ import com.dirtfy.ppp.ui.state.feature.record.atom.UiRecordDetail
 import javax.inject.Inject
 
 class RecordDetailScreen @Inject constructor(
-    val recordDetailController: RecordDetailController
+    val recordController: RecordController
 ){
 
     @Composable
     fun Main(
-        firstRecord: UiRecord,
-        controller: RecordDetailController = recordDetailController
+        controller: RecordController = recordController
     ) {
         val screenData by controller.screenData.collectAsStateWithLifecycle()
 
         LaunchedEffect(key1 = controller) {
             controller.run {
-                updateRecordDetailList(firstRecord)
-                updateNowRecord(firstRecord)
+                updateRecordDetailList()
             }
         }
 
@@ -55,7 +53,7 @@ class RecordDetailScreen @Inject constructor(
             recordDetailList = screenData.recordDetailList,
             recordDetailListState = screenData.recordDetailListState,
             onRetryClick = {
-                controller.request { updateRecordDetailList(screenData.nowRecord) }
+                controller.request { updateRecordDetailList() }
             }
         )
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordScreen.kt
@@ -50,9 +50,10 @@ class RecordScreen @Inject constructor(
             mode = screenData.mode,
             onClueChanged = { controller.updateSearchClue(it) },
             onItemClick = {
-                controller.run{
-                    updateNowRecord(it)
+                controller.request{
                     setMode(UiRecordMode.Detail)
+                    updateNowRecord(it)
+                    updateRecordDetailList()
                 }
             },
             onDismissRequest = {

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordScreen.kt
@@ -94,7 +94,6 @@ class RecordScreen @Inject constructor(
             when(mode) {
                 UiRecordMode.Detail -> {
                     RecordDetailDialog(
-                        nowAccount = nowRecord,
                         onDismissRequest = onDismissRequest
                     )
                 }
@@ -178,11 +177,10 @@ class RecordScreen @Inject constructor(
 
     @Composable
     fun RecordDetailDialog(
-        nowAccount: UiRecord,
         onDismissRequest: () -> Unit
     ) {
         Dialog(onDismissRequest = onDismissRequest) {
-            recordDetailScreen.Main(firstRecord = nowAccount)
+            recordDetailScreen.Main()
         }
     }
 }


### PR DESCRIPTION
#62 의 구조로 Record Controller 들을 통합하고, 재구성하였습니다.

최상위 클래스이자 AndroidViewModel 클래스인 
RecordController <- RecordViewModel 이 다음의 하위 일반클래스를 사용합니다.

1. RecordListController - Record 리스트를 활용하는 작업 전반을 담당
2. RecordDetailController - 한 Record에 대해 세부정보를 표시하는 작업 전반을 담당

해당 변경 과정에서, 기존에 updateNowRecord( ) 함수에서 updateRecordDetailList( ) 의 역할까지 진행하던 것을 완전히 분리하였습니다.