### PR TITLE
MenuControllers Refactoring

### DIFF
--- a/app/src/main/java/com/dirtfy/ppp/common/di/ControllerModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/ControllerModule.kt
@@ -8,6 +8,10 @@ import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountCreate
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountDetailControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountListControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel.AccountUpdateControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.menu.MenuListController
+import com.dirtfy.ppp.ui.controller.feature.menu.MenuUpdateController
+import com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel.MenuListControllerImpl
+import com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel.MenuUpdateControllerImpl
 import com.dirtfy.ppp.ui.controller.feature.record.RecordDetailController
 import com.dirtfy.ppp.ui.controller.feature.record.RecordListController
 import com.dirtfy.ppp.ui.controller.feature.record.impl.viewmodel.RecordDetailControllerImpl
@@ -70,4 +74,14 @@ abstract class ControllerModule {
     abstract fun bindsRecordDetailController(
         controllerImpl: RecordDetailControllerImpl
     ): RecordDetailController
+
+    @Binds
+    abstract fun bindsMenuListController(
+        controllerImpl: MenuListControllerImpl
+    ): MenuListController
+
+    @Binds
+    abstract fun bindsMenuUpdateController(
+        controllerImpl: MenuUpdateControllerImpl
+    ): MenuUpdateController
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuController.kt
@@ -12,7 +12,7 @@ interface MenuController: Controller<UiMenuScreenState, MenuController> {
     fun updateSearchClue(clue: String)
     fun updateNewMenu(menu: UiMenu)
 
-    suspend fun createMenu(menu: UiMenu)
+    suspend fun createMenu()
     suspend fun deleteMenu(menu: UiMenu)
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuListController.kt
@@ -1,0 +1,14 @@
+package com.dirtfy.ppp.ui.controller.feature.menu
+
+import com.dirtfy.ppp.ui.state.feature.menu.UiMenuListScreenState
+import kotlinx.coroutines.flow.Flow
+
+interface MenuListController {
+
+    val screenData: Flow<UiMenuListScreenState>
+
+    @Deprecated("screen state synchronized with repository")
+    suspend fun updateMenuList()
+
+    fun updateSearchClue(clue: String)
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuUpdateController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuUpdateController.kt
@@ -10,6 +10,6 @@ interface MenuUpdateController {
 
     fun updateNewMenu(menu: UiMenu)
 
-    suspend fun createMenu(menu: UiMenu)
+    suspend fun createMenu()
     suspend fun deleteMenu(menu: UiMenu)
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuUpdateController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/MenuUpdateController.kt
@@ -1,0 +1,15 @@
+package com.dirtfy.ppp.ui.controller.feature.menu
+
+import com.dirtfy.ppp.ui.state.feature.menu.UiMenuUpdateScreenState
+import com.dirtfy.ppp.ui.state.feature.menu.atom.UiMenu
+import kotlinx.coroutines.flow.Flow
+
+interface MenuUpdateController {
+
+    val screenData: Flow<UiMenuUpdateScreenState>
+
+    fun updateNewMenu(menu: UiMenu)
+
+    suspend fun createMenu(menu: UiMenu)
+    suspend fun deleteMenu(menu: UiMenu)
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuListControllerImpl.kt
@@ -1,0 +1,59 @@
+package com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel
+
+import com.dirtfy.ppp.data.logic.MenuBusinessLogic
+import com.dirtfy.ppp.ui.controller.common.converter.feature.menu.MenuAtomConverter.convertToUiMenu
+import com.dirtfy.ppp.ui.controller.feature.menu.MenuListController
+import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.common.UiState
+import com.dirtfy.ppp.ui.state.feature.menu.UiMenuListScreenState
+import com.dirtfy.ppp.ui.state.feature.menu.atom.UiMenu
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+class MenuListControllerImpl @Inject constructor(
+    private val menuBusinessLogic: MenuBusinessLogic
+): MenuListController {
+
+    private val _screenData: MutableStateFlow<UiMenuListScreenState>
+        = MutableStateFlow(UiMenuListScreenState())
+
+    private val menuListFlow: Flow<List<UiMenu>> = menuBusinessLogic.menuStream()
+        .map { it.map { menu -> menu.convertToUiMenu() } }
+        .catch { cause ->
+            _screenData.update { it.copy(menuListState = UiScreenState(UiState.FAIL, cause.message)) }
+        }
+
+    override val screenData: Flow<UiMenuListScreenState>
+         = _screenData
+        .combine(menuListFlow) { state, menuList ->
+            val filteredList = menuList.filter {
+                it.name.contains(state.searchClue)
+            }
+
+            var newState = state.copy(
+                menuList = filteredList
+            )
+
+            if (state.menuList != menuList /* 내용이 달라졌을 때 */
+                || state.menuList !== menuList /* 내용이 같지만 다른 인스턴스 */
+                || menuList == emptyList<UiMenu>() /* emptyList()는 항상 같은 인스턴스 */)
+                newState = newState.copy(
+                    menuListState = UiScreenState(UiState.COMPLETE)
+                )
+
+            newState
+        }
+
+    @Deprecated("screen state synchronized with repository")
+    override suspend fun updateMenuList() {
+    }
+
+    override fun updateSearchClue(clue: String) {
+        _screenData.update { it.copy(searchClue = clue) }
+    }
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuUpdateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuUpdateControllerImpl.kt
@@ -30,8 +30,10 @@ class MenuUpdateControllerImpl @Inject constructor(
         _screenData.update { it.copy(newMenu = menu) }
     }
 
-    override suspend fun createMenu(menu: UiMenu) {
+    override suspend fun createMenu() {
         _screenData.update { it.copy(addMenuState = UiScreenState(UiState.LOADING)) }
+
+        val menu = _screenData.value.newMenu
 
         if (menu.name == "") {
             _screenData.update { it.copy(

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuUpdateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuUpdateControllerImpl.kt
@@ -1,0 +1,82 @@
+package com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel
+
+import android.util.Log
+import com.dirtfy.ppp.common.exception.MenuException
+import com.dirtfy.ppp.data.logic.MenuBusinessLogic
+import com.dirtfy.ppp.ui.controller.common.converter.feature.menu.MenuAtomConverter.convertToDataMenu
+import com.dirtfy.ppp.ui.controller.feature.menu.MenuUpdateController
+import com.dirtfy.ppp.ui.state.common.UiScreenState
+import com.dirtfy.ppp.ui.state.common.UiState
+import com.dirtfy.ppp.ui.state.feature.menu.UiMenuUpdateScreenState
+import com.dirtfy.ppp.ui.state.feature.menu.atom.UiMenu
+import com.dirtfy.tagger.Tagger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+class MenuUpdateControllerImpl @Inject constructor(
+    private val menuBusinessLogic: MenuBusinessLogic
+): MenuUpdateController, Tagger {
+
+    private val _screenData: MutableStateFlow<UiMenuUpdateScreenState>
+        = MutableStateFlow(UiMenuUpdateScreenState())
+
+    override val screenData: Flow<UiMenuUpdateScreenState>
+        get() = _screenData
+
+    override fun updateNewMenu(menu: UiMenu) {
+        _screenData.update { it.copy(newMenu = menu) }
+    }
+
+    override suspend fun createMenu(menu: UiMenu) {
+        _screenData.update { it.copy(addMenuState = UiScreenState(UiState.LOADING)) }
+
+        if (menu.name == "") {
+            _screenData.update { it.copy(
+                addMenuState = UiScreenState(UiState.FAIL, MenuException.BlankName().message)
+            ) }
+            return
+        }
+        if (menu.price == "") {
+            _screenData.update { it.copy(
+                addMenuState = UiScreenState(UiState.FAIL, MenuException.BlankPrice().message)
+            ) }
+            return
+        }
+
+        menuBusinessLogic.createMenu(
+            menu.convertToDataMenu()
+        ).catch { cause ->
+            Log.e(TAG, "createMenu() - createMenu failed")
+            _screenData.update { it.copy(
+                addMenuState = UiScreenState(UiState.FAIL, cause.message)
+            ) }
+        }.collect {
+            _screenData.update { it.copy(
+                newMenu = UiMenu(),
+                addMenuState = UiScreenState(UiState.COMPLETE)
+            ) }
+        }
+    }
+
+    override suspend fun deleteMenu(menu: UiMenu) {
+        _screenData.update { it.copy(
+            deleteMenuState = UiScreenState(UiState.LOADING)
+        ) }
+
+        menuBusinessLogic.deleteMenu(
+            menu.convertToDataMenu()
+        ).catch { cause ->
+            Log.e(TAG, "deleteMenu() - deleteMenu failed")
+            _screenData.update { it.copy(
+                deleteMenuState = UiScreenState(UiState.FAIL, cause.message)
+            ) }
+        }.collect {
+            _screenData.update { it.copy(
+                deleteMenuState = UiScreenState(UiState.COMPLETE)
+            ) }
+        }
+    }
+}

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuViewModel.kt
@@ -1,143 +1,63 @@
 package com.dirtfy.ppp.ui.controller.feature.menu.impl.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dirtfy.ppp.common.exception.MenuException
-import com.dirtfy.ppp.data.logic.MenuBusinessLogic
-import com.dirtfy.ppp.ui.controller.common.converter.feature.menu.MenuAtomConverter.convertToDataMenu
-import com.dirtfy.ppp.ui.controller.common.converter.feature.menu.MenuAtomConverter.convertToUiMenu
 import com.dirtfy.ppp.ui.controller.feature.menu.MenuController
-import com.dirtfy.ppp.ui.state.common.UiScreenState
-import com.dirtfy.ppp.ui.state.common.UiState
+import com.dirtfy.ppp.ui.controller.feature.menu.MenuListController
+import com.dirtfy.ppp.ui.controller.feature.menu.MenuUpdateController
 import com.dirtfy.ppp.ui.state.feature.menu.UiMenuScreenState
 import com.dirtfy.ppp.ui.state.feature.menu.atom.UiMenu
 import com.dirtfy.tagger.Tagger
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MenuViewModel @Inject constructor(
-    private val menuBusinessLogic: MenuBusinessLogic
+    private val listController: MenuListController,
+    private val updateController: MenuUpdateController
 ): ViewModel(), MenuController, Tagger {
 
-    private val menuListFlow: Flow<List<UiMenu>> = menuBusinessLogic.menuStream().map {
-        it.map { menu -> menu.convertToUiMenu() }
-    }
-
-    private val searchClueFlow = MutableStateFlow("")
-    private val newMenuFlow = MutableStateFlow(UiMenu())
-    private val newMenuStateFlow = MutableStateFlow(UiScreenState(UiState.COMPLETE))
-    private val deleteMenuStateFlow = MutableStateFlow(UiScreenState(UiState.COMPLETE))
-
     override val screenData: StateFlow<UiMenuScreenState>
-        = searchClueFlow
-            .combine(newMenuFlow) { searchClue, newMenu ->
-                UiMenuScreenState(
-                    searchClue = searchClue,
-                    newMenu = newMenu
-                )
-            }
-            .combine(newMenuStateFlow) { state, newMenuState ->
-                state.copy(
-                    newMenuState = newMenuState
-                )
-            }
-            .combine(deleteMenuStateFlow) { state, deleteMenuState ->
-                state.copy(
-                    deleteMenuState = deleteMenuState
-                )
-            }
-            .combine(menuListFlow) { state, menuList ->
-                val filteredList = menuList.filter {
-                    it.name.contains(state.searchClue)
-                }
-
-                var newState = state.copy(
-                    menuList = filteredList
-                )
-
-                if (state.menuList != menuList /* 내용이 달라졌을 때 */
-                    || state.menuList !== menuList /* 내용이 같지만 다른 인스턴스 */
-                    || menuList == emptyList<UiMenu>() /* emptyList()는 항상 같은 인스턴스 */)
-                    newState = newState.copy(
-                        menuListState = UiScreenState(UiState.COMPLETE)
-                    )
-
-                newState
-            }
-            .catch { cause ->
-                Log.e(TAG, "uiMenuScreenState - combine failed \n ${cause.message}")
-
-                // TODO 더 기가 막힌 방법 생각해보기
-                UiMenuScreenState(
-                    searchClue = searchClueFlow.value,
-                    newMenu = newMenuFlow.value,
-                    menuListState = UiScreenState(UiState.FAIL, cause.message)
-                )
-            }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = UiMenuScreenState()
+        = listController.screenData
+        .combine(updateController.screenData) { listScreenData, updateScreenData ->
+            UiMenuScreenState(
+                menuList = listScreenData.menuList,
+                searchClue = listScreenData.searchClue,
+                newMenu = updateScreenData.newMenu,
+                menuListState = listScreenData.menuListState,
+                addMenuState = updateScreenData.addMenuState,
+                deleteMenuState = updateScreenData.deleteMenuState
             )
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UiMenuScreenState()
+        )
 
     @Deprecated("screen state synchronized with repository")
     override suspend fun updateMenuList() {
-
     }
 
     override fun updateSearchClue(clue: String) {
-        searchClueFlow.update { clue }
+        listController.updateSearchClue(clue)
     }
 
     override fun updateNewMenu(menu: UiMenu) {
-        newMenuFlow.update { menu }
+        updateController.updateNewMenu(menu)
     }
 
-    override suspend fun createMenu(menu: UiMenu) {
-        newMenuStateFlow.update { UiScreenState(UiState.LOADING) }
-        if (menu.name == "") {
-            newMenuStateFlow.update { UiScreenState(UiState.FAIL, MenuException.BlankName().message) }
-            return
-        }
-        if (menu.price == "") {
-            newMenuStateFlow.update { UiScreenState(UiState.FAIL, MenuException.BlankPrice().message) }
-            return
-        }
-
-        menuBusinessLogic.createMenu(
-            menu.convertToDataMenu()
-        ).catch { cause ->
-            Log.e(TAG, "createMenu() - createMenu failed")
-            newMenuStateFlow.update { UiScreenState(UiState.FAIL, cause.message) }
-        }.collect {
-            newMenuFlow.update { UiMenu() }
-            newMenuStateFlow.update { UiScreenState(UiState.COMPLETE) }
-        }
+    override suspend fun createMenu() {
+        updateController.createMenu(screenData.value.newMenu)
     }
 
     override suspend fun deleteMenu(menu: UiMenu) {
-        deleteMenuStateFlow.update { UiScreenState(UiState.LOADING) }
-
-        menuBusinessLogic.deleteMenu(
-            menu.convertToDataMenu()
-        ).catch { cause ->
-            Log.e(TAG, "deleteMenu() - deleteMenu failed")
-            deleteMenuStateFlow.update { UiScreenState(UiState.FAIL, cause.message) }
-        }.collect {
-            deleteMenuStateFlow.update { UiScreenState(UiState.COMPLETE) }
-        }
+        updateController.deleteMenu(menu)
     }
 
     override fun request(job: suspend MenuController.() -> Unit) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/menu/impl/viewmodel/MenuViewModel.kt
@@ -53,7 +53,7 @@ class MenuViewModel @Inject constructor(
     }
 
     override suspend fun createMenu() {
-        updateController.createMenu(screenData.value.newMenu)
+        updateController.createMenu()
     }
 
     override suspend fun deleteMenu(menu: UiMenu) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/menu/UiMenuListScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/menu/UiMenuListScreenState.kt
@@ -1,15 +1,11 @@
 package com.dirtfy.ppp.ui.state.feature.menu
 
 import com.dirtfy.ppp.ui.state.common.UiScreenState
-import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.menu.atom.UiMenu
 
-data class UiMenuScreenState(
+data class UiMenuListScreenState(
     val menuList: List<UiMenu> = emptyList(),
     val searchClue: String = "",
-    val newMenu: UiMenu = UiMenu(),
 
     val menuListState: UiScreenState = UiScreenState(),
-    val addMenuState: UiScreenState = UiScreenState(UiState.COMPLETE),
-    val deleteMenuState: UiScreenState = UiScreenState(UiState.COMPLETE)
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/menu/UiMenuUpdateScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/menu/UiMenuUpdateScreenState.kt
@@ -4,12 +4,9 @@ import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.menu.atom.UiMenu
 
-data class UiMenuScreenState(
-    val menuList: List<UiMenu> = emptyList(),
-    val searchClue: String = "",
+data class UiMenuUpdateScreenState(
     val newMenu: UiMenu = UiMenu(),
 
-    val menuListState: UiScreenState = UiScreenState(),
     val addMenuState: UiScreenState = UiScreenState(UiState.COMPLETE),
-    val deleteMenuState: UiScreenState = UiScreenState(UiState.COMPLETE)
+    val deleteMenuState: UiScreenState = UiScreenState(UiState.COMPLETE),
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/menu/MenuScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/menu/MenuScreen.kt
@@ -77,7 +77,7 @@ class MenuScreen @Inject constructor(
             NewMenuSection(
                 newMenu = screen.newMenu,
                 onMenuChanged = { controller.request { updateNewMenu(it) } },
-                onMenuAdd = { controller.request { createMenu(it) } }
+                onMenuAdd = { controller.request { createMenu() } }
             )
 
             Spacer(modifier = Modifier.size(24.dp))

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/menu/MenuScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/menu/MenuScreen.kt
@@ -64,7 +64,7 @@ class MenuScreen @Inject constructor(
             NewMenu(
                 newMenu = screen.newMenu,
                 onMenuChanged = { controller.updateNewMenu(it) },
-                onMenuAdd = { controller.request { createMenu(it) } }
+                onMenuAdd = { controller.request { createMenu() } }
             )
 
             Spacer(modifier = Modifier.size(10.dp))


### PR DESCRIPTION
#62 의 구조를 참고하여 MenuController 에 해당 구조를 적용하였습니다.

최상위 AndroidViewModel 클래스인 MenuController <- MenuViewModel이 다음의 하위 클래스를 사용합니다.

1. MenuListController - 현재 존재하는 메뉴의 리스트를 관리하고, 검색 기능까지 적용된 메뉴리스트를 보여주는 역할을 담당.
2. MenuUpdateController - 새로운 메뉴를 추가하거나, 기존 메뉴를 삭제하는 기능을 담당.

<br>

[추가 변경사항]
+ 기존 UiMenuScreenState 내부의 newMenuState 변수의 이름이 addMenuState로 변경됨.
+ 기존 MenuController 멤버 함수 createMenu(menu: UiMenu)의 시그니처가 createMenu()로 변경되고, screenData 내부에 있는 newMenu 변수의 값을 활용하도록 수정함.