### PR TITLE
Stabilize and Improve Performance of Concurrent Table Tasks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:name="android.hardware.camera"
         android:required="true" />
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".common.di.PPP"

--- a/app/src/main/java/com/dirtfy/ppp/common/di/DataModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/DataModule.kt
@@ -1,10 +1,14 @@
 package com.dirtfy.ppp.common.di
 
 import com.dirtfy.ppp.data.api.AccountApi
+import com.dirtfy.ppp.data.api.ApiProvider
 import com.dirtfy.ppp.data.api.MenuApi
 import com.dirtfy.ppp.data.api.RecordApi
 import com.dirtfy.ppp.data.api.TableApi
-import com.dirtfy.ppp.data.api.impl.common.firebase.FireStoreManager
+import com.dirtfy.ppp.data.api.TransactionManager
+import com.dirtfy.ppp.data.api.impl.common.firebase.FireStoreProvider
+import com.dirtfy.ppp.data.api.impl.common.firebase.FireStoreTransactionManager
+import com.google.firebase.firestore.Transaction
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,23 +19,33 @@ import dagger.hilt.components.SingletonComponent
 class DataModule {
 
     @Provides
+    fun providesApiProvider(): ApiProvider {
+        return FireStoreProvider.getInstance()
+    }
+
+    @Provides
+    fun providesTransactionManager(): TransactionManager<Transaction> {
+        return FireStoreTransactionManager()
+    }
+
+    @Provides
     fun providesAccountApi(): AccountApi {
-        return FireStoreManager.getInstance().accountFireStore
+        return providesApiProvider().accountApi
     }
 
     @Provides
     fun providesMenuApi(): MenuApi {
-        return FireStoreManager.getInstance().menuFireStore
+        return providesApiProvider().menuApi
     }
 
     @Provides
     fun providesRecordApi(): RecordApi {
-        return FireStoreManager.getInstance().recordFireStore
+        return providesApiProvider().recordApi
     }
 
     @Provides
     fun providesTableApi(): TableApi {
-        return FireStoreManager.getInstance().tableFireStore
+        return providesApiProvider().tableApi
     }
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/AccountException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/AccountException.kt
@@ -18,4 +18,8 @@ sealed class AccountException(
     class PhoneNumberLoss: AccountException("phone number is not found")
     class BalanceLoss: AccountException("balance is not found")
     class RegisterTimestampLoss: AccountException("register timestamp is not found")
+
+    class BlankNumber: MenuException("account number can not be a blank")
+    class BlankName: MenuException("account name can not be a blank")
+    class BlankPhoneNumber: MenuException("account phone number can not be a blank")
 }

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/AccountException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/AccountException.kt
@@ -19,7 +19,10 @@ sealed class AccountException(
     class BalanceLoss: AccountException("balance is not found")
     class RegisterTimestampLoss: AccountException("register timestamp is not found")
 
-    class BlankNumber: MenuException("account number can not be a blank")
-    class BlankName: MenuException("account name can not be a blank")
-    class BlankPhoneNumber: MenuException("account phone number can not be a blank")
+    class BlankNumber: AccountException("account number can not be a blank")
+    class BlankName: AccountException("account name can not be a blank")
+    class BlankPhoneNumber: AccountException("account phone number can not be a blank")
+    class BlankIssuedName: AccountException("record issued name can not be a blank")
+    class BlankDifference: AccountException("record difference can not be a blank")
+
 }

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
@@ -6,7 +6,6 @@ sealed class TableException(
     class InvalidTableNumber: TableException("it's invalid table number")
     class InvalidPay: TableException("it's invalid pay")
 
-    @Deprecated("change repository structure")
     class GroupLoss: TableException("group is not found")
     class NumberLoss: TableException("number is not found")
     class NameLoss: TableException("name is not found")
@@ -21,5 +20,6 @@ sealed class TableException(
 
     class NonEnoughMergingTargets: TableException("number of merging table is not enough")
     class NonEnoughMenuToCancel: TableException("menu count can not be minus")
+    class IllegalGroupIdAssignment: RecordException("id is already assigned (illegal)")
     class InValidGroupState: TableException("group table has error!")
 }

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
@@ -6,6 +6,7 @@ sealed class TableException(
     class InvalidTableNumber: TableException("it's invalid table number")
     class InvalidPay: TableException("it's invalid pay")
 
+    @Deprecated("change repository structure")
     class GroupLoss: TableException("group is not found")
     class NumberLoss: TableException("number is not found")
     class NameLoss: TableException("name is not found")

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
@@ -11,7 +11,7 @@ sealed class TableException(
     class InvalidPay: TableException("it's invalid pay")
 
     class GroupLoss: TableException("group is not found")
-    class NumberLoss: TableException("number is not found")
+    class TableLoss: TableException("table is not found")
     class NameLoss: TableException("name is not found")
     class PriceLoss: TableException("price is not found")
     class CountLoss: TableException("count is not found")

--- a/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
@@ -3,6 +3,10 @@ package com.dirtfy.ppp.common.exception
 sealed class TableException(
     massage: String
 ): CustomException(massage) {
+
+    class TableLockPreempted: TableException("simultaneous group edition is not allowed")
+    class IllegalMergeModeSet: TableException("setMode(Merge) is not allowed. use trySetMergeMode()")
+
     class InvalidTableNumber: TableException("it's invalid table number")
     class InvalidPay: TableException("it's invalid pay")
 

--- a/app/src/main/java/com/dirtfy/ppp/data/api/ApiProvider.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/ApiProvider.kt
@@ -1,0 +1,8 @@
+package com.dirtfy.ppp.data.api
+
+interface ApiProvider {
+    val accountApi: AccountApi
+    val recordApi: RecordApi
+    val menuApi: MenuApi
+    val tableApi: TableApi
+}

--- a/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
@@ -2,11 +2,13 @@ package com.dirtfy.ppp.data.api
 
 import com.dirtfy.ppp.data.dto.feature.record.DataRecord
 import com.dirtfy.ppp.data.dto.feature.record.DataRecordDetail
+import com.google.firebase.firestore.Transaction
 import kotlinx.coroutines.flow.Flow
 
 interface RecordApi {
 
     suspend fun create(record: DataRecord, detailList: List<DataRecordDetail>): DataRecord
+    fun create(record: DataRecord, detailList: List<DataRecordDetail>, transaction: Transaction): DataRecord
     suspend fun read(id: Int): DataRecord
     suspend fun readAll(): List<DataRecord>
     suspend fun <ValueType> readRecordWith(key: String, value: ValueType): List<DataRecord>

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -27,6 +27,8 @@ interface TableApi {
     /*suspend fun updateOrder(tableNumber: Int, order: DataTableOrder)*/
     suspend fun setOrder(groupNumber: Int, order: DataTableOrder)
     fun setOrder(groupNumber: Int, order: DataTableOrder, transaction: Transaction)
+    fun incrementOrder(groupNumber: Int, menuName: String, transaction: Transaction)
+    fun decrementOrder(groupNumber: Int, menuName: String, transaction: Transaction)
     suspend fun deleteOrder(groupNumber: Int, menuName: String)
     fun deleteOrder(groupNumber: Int, menuName: String, transaction: Transaction)
     suspend fun deleteAllOrder(groupNumber: Int)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -7,6 +7,9 @@ import com.google.firebase.firestore.Transaction
 import kotlinx.coroutines.flow.Flow
 
 interface TableApi {
+    companion object {
+        const val TABLE_GROUP_LOCK_EXPIRE_TIME_MILLISECONDS = 30000L // 30초
+    }
 
     fun createGroup(group: DataTableGroup, transaction: Transaction): DataTableGroup
     fun deleteGroup(groupNumber: Int, transaction: Transaction)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -1,6 +1,5 @@
 package com.dirtfy.ppp.data.api
 
-import com.dirtfy.ppp.data.api.impl.feature.table.firebase.FireStoreTableOrder
 import com.dirtfy.ppp.data.dto.feature.table.DataTable
 import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.data.dto.feature.table.DataTableOrder
@@ -9,6 +8,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface TableApi {
 
+    fun createGroup(group: DataTableGroup, transaction: Transaction): DataTableGroup
+    fun deleteGroup(groupNumber: Int, transaction: Transaction)
     suspend fun readTable(tableNumber: Int): DataTable
     suspend fun readAllTable(): List<DataTable>
     suspend fun updateTable(table: DataTable)
@@ -20,15 +21,20 @@ interface TableApi {
         menuName: String,
         menuPrice: Int
     )*/
-    suspend fun readOrder(tableNumber: Int, menuName: String): DataTableOrder
-    suspend fun readAllOrder(tableNumber: Int): List<DataTableOrder>
+    suspend fun readOrder(groupNumber: Int, menuName: String): DataTableOrder
+    fun readOrder(groupNumber: Int, menuName: String, transaction: Transaction): DataTableOrder
+    suspend fun readAllOrder(groupNumber: Int): List<DataTableOrder>
     /*suspend fun updateOrder(tableNumber: Int, order: DataTableOrder)*/
-    suspend fun setOrder(tableNumber: Int, order: DataTableOrder)
-    fun setOrder(tableNumber: Int, order: DataTableOrder, transaction: Transaction)
-    suspend fun deleteOrder(tableNumber: Int, menuName: String)
-    suspend fun deleteAllOrder(tableNumber: Int)
-    fun deleteOrders(tableNumber: Int, orderList: List<DataTableOrder>, transaction: Transaction)
-    fun orderStream(tableNumber: Int): Flow<List<DataTableOrder>>
+    suspend fun setOrder(groupNumber: Int, order: DataTableOrder)
+    fun setOrder(groupNumber: Int, order: DataTableOrder, transaction: Transaction)
+    suspend fun deleteOrder(groupNumber: Int, menuName: String)
+    fun deleteOrder(groupNumber: Int, menuName: String, transaction: Transaction)
+    suspend fun deleteAllOrder(groupNumber: Int)
+    fun deleteOrders(groupNumber: Int, orderList: List<DataTableOrder>, transaction: Transaction)
+    fun orderStream(groupNumber: Int): Flow<List<DataTableOrder>>
 
-    suspend fun isOrderExist(tableNumber: Int, menuName: String): Boolean
+    suspend fun isGroupExist(groupNumber: Int): Boolean
+    fun isGroupExist(groupNumber: Int, transaction: Transaction): Boolean
+    suspend fun isOrderExist(groupNumber: Int, menuName: String): Boolean
+    fun isOrderExist(groupNumber: Int, menuName: String, transaction: Transaction): Boolean
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -1,5 +1,6 @@
 package com.dirtfy.ppp.data.api
 
+import com.dirtfy.ppp.data.api.impl.feature.table.firebase.FireStoreTableOrder
 import com.dirtfy.ppp.data.dto.feature.table.DataTable
 import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.data.dto.feature.table.DataTableOrder

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -12,25 +12,17 @@ interface TableApi {
     }
 
     fun createGroup(group: DataTableGroup, transaction: Transaction): DataTableGroup
-    fun deleteGroup(groupNumber: Int, transaction: Transaction)
+    fun deleteGroup(groupNumber: Int, orderList: List<DataTableOrder>, transaction: Transaction)
     suspend fun readTable(tableNumber: Int): DataTable
-    suspend fun readAllTable(): List<DataTable>
-    suspend fun updateTable(table: DataTable)
+    suspend fun readAllGroupedTable(): List<DataTable>
     fun checkTableGroupLock(transaction: Transaction)
     fun getTableGroupLock(transaction: Transaction)
     fun releaseTableGroupLock(transaction: Transaction)
-    fun combineGroup(group1: DataTableGroup, group2: DataTableGroup, transaction: Transaction): DataTableGroup
     fun tableStream(): Flow<List<DataTable>>
 
-    /*suspend fun createOrder(
-        tableNumber: Int,
-        menuName: String,
-        menuPrice: Int
-    )*/
     suspend fun readOrder(groupNumber: Int, menuName: String): DataTableOrder
     fun readOrder(groupNumber: Int, menuName: String, transaction: Transaction): DataTableOrder
     suspend fun readAllOrder(groupNumber: Int): List<DataTableOrder>
-    /*suspend fun updateOrder(tableNumber: Int, order: DataTableOrder)*/
     suspend fun setOrder(groupNumber: Int, order: DataTableOrder)
     fun setOrder(groupNumber: Int, order: DataTableOrder, transaction: Transaction)
     fun incrementOrder(groupNumber: Int, menuName: String, transaction: Transaction)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -13,6 +13,9 @@ interface TableApi {
     suspend fun readTable(tableNumber: Int): DataTable
     suspend fun readAllTable(): List<DataTable>
     suspend fun updateTable(table: DataTable)
+    fun checkTableGroupLock(transaction: Transaction)
+    fun getTableGroupLock(transaction: Transaction)
+    fun releaseTableGroupLock(transaction: Transaction)
     fun combineGroup(group1: DataTableGroup, group2: DataTableGroup, transaction: Transaction): DataTableGroup
     fun tableStream(): Flow<List<DataTable>>
 

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -1,8 +1,9 @@
 package com.dirtfy.ppp.data.api
 
-import com.dirtfy.ppp.data.api.impl.feature.table.firebase.FireStoreTableOrder
 import com.dirtfy.ppp.data.dto.feature.table.DataTable
+import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.data.dto.feature.table.DataTableOrder
+import com.google.firebase.firestore.Transaction
 import kotlinx.coroutines.flow.Flow
 
 interface TableApi {
@@ -10,6 +11,7 @@ interface TableApi {
     suspend fun readTable(tableNumber: Int): DataTable
     suspend fun readAllTable(): List<DataTable>
     suspend fun updateTable(table: DataTable)
+    fun combineGroup(group1: DataTableGroup, group2: DataTableGroup, transaction: Transaction): DataTableGroup
     fun tableStream(): Flow<List<DataTable>>
 
     /*suspend fun createOrder(
@@ -21,8 +23,10 @@ interface TableApi {
     suspend fun readAllOrder(tableNumber: Int): List<DataTableOrder>
     /*suspend fun updateOrder(tableNumber: Int, order: DataTableOrder)*/
     suspend fun setOrder(tableNumber: Int, order: DataTableOrder)
+    fun setOrder(tableNumber: Int, order: DataTableOrder, transaction: Transaction)
     suspend fun deleteOrder(tableNumber: Int, menuName: String)
     suspend fun deleteAllOrder(tableNumber: Int)
+    fun deleteOrders(tableNumber: Int, orderList: List<DataTableOrder>, transaction: Transaction)
     fun orderStream(tableNumber: Int): Flow<List<DataTableOrder>>
 
     suspend fun isOrderExist(tableNumber: Int, menuName: String): Boolean

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TransactionManager.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TransactionManager.kt
@@ -1,0 +1,7 @@
+package com.dirtfy.ppp.data.api
+
+interface TransactionManager<TransactionType> {
+    suspend fun <ReturnType> transaction(
+        job: (transaction: TransactionType) -> ReturnType
+    ): ReturnType
+}

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStorePath.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStorePath.kt
@@ -6,6 +6,7 @@ object FireStorePath {
 
     const val MAX_ACCOUNT_NUMBER: String = "$CONSTANT/MAX_ACCOUNT_NUMBER"
     const val RECORD_ID_COUNT: String = "$CONSTANT/RECORD_ID_COUNT"
+    const val GROUP_ID_COUNT: String = "$CONSTANT/GROUP_ID_COUNT"
 
     const val ACCOUNT: String = "account_exp"
 

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStorePath.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStorePath.kt
@@ -18,5 +18,8 @@ object FireStorePath {
     const val TABLE: String = "table_exp"
     const val TABLE_ORDER: String = "order"
 
+    private const val LOCK: String = "lock_exp"
+
+    const val TABLE_GROUP_LOCK = "$LOCK/TABLE_GROUP_LOCK"
 
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStoreProvider.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStoreProvider.kt
@@ -1,5 +1,6 @@
 package com.dirtfy.ppp.data.api.impl.common.firebase
 
+import com.dirtfy.ppp.data.api.ApiProvider
 import com.dirtfy.ppp.data.api.impl.feature.account.firebase.AccountFireStore
 import com.dirtfy.ppp.data.api.impl.feature.menu.firebase.MenuFireStore
 import com.dirtfy.ppp.data.api.impl.feature.record.firebase.RecordFireStore
@@ -8,7 +9,7 @@ import com.google.firebase.firestore.FirebaseFirestoreSettings
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
-class FireStoreManager private constructor() {
+class FireStoreProvider private constructor(): ApiProvider {
     init {
         Firebase.firestore.firestoreSettings = FirebaseFirestoreSettings.Builder()
             .setPersistenceEnabled(false) // TODO deprecated function call
@@ -16,18 +17,18 @@ class FireStoreManager private constructor() {
     }
 
     companion object {
-        private var instance: FireStoreManager? = null
-
-        fun getInstance(): FireStoreManager {
+        private var instance: FireStoreProvider? = null
+        fun getInstance(): FireStoreProvider {
             if (instance == null)
-                instance = FireStoreManager()
+                instance = FireStoreProvider()
 
-            return instance as FireStoreManager
+            return instance as FireStoreProvider
         }
     }
 
-    val accountFireStore = AccountFireStore()
-    val menuFireStore = MenuFireStore()
-    val recordFireStore = RecordFireStore()
-    val tableFireStore = TableFireStore()
+    override val accountApi = AccountFireStore()
+    override val menuApi = MenuFireStore()
+    override val recordApi = RecordFireStore()
+    override val tableApi = TableFireStore()
+
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStoreTransactionManager.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/common/firebase/FireStoreTransactionManager.kt
@@ -1,0 +1,23 @@
+package com.dirtfy.ppp.data.api.impl.common.firebase
+
+import com.dirtfy.ppp.data.api.TransactionManager
+import com.google.firebase.firestore.Transaction
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
+
+class FireStoreTransactionManager: TransactionManager<Transaction> {
+//    override suspend fun <TransactionType, ReturnType> transaction(
+//        job: (transaction: TransactionType) -> ReturnType
+//    ): ReturnType {
+//        return Firebase.firestore.runTransaction {
+//            job(it)
+//        }.await()
+//    }
+
+    override suspend fun <ReturnType> transaction(job: (transaction: Transaction) -> ReturnType): ReturnType {
+        return Firebase.firestore.runTransaction {
+            job(it)
+        }.await()
+    }
+}

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/account/firebase/AccountFireStore.kt
@@ -149,7 +149,7 @@ class AccountFireStore @Inject constructor(): AccountApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "accountStream snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 val accountList = readAllAccount(snapshot)
                 trySend(accountList)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/menu/firebase/MenuFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/menu/firebase/MenuFireStore.kt
@@ -76,7 +76,7 @@ class MenuFireStore @Inject constructor(): MenuApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "menuStream snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 val menuList = readAll(snapshot)
                 trySend(menuList)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
@@ -125,7 +125,7 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
     override suspend fun readDetail(record: DataRecord): List<DataRecordDetail> {
         val detailSnapshot = recordRef.document(record.id.toString())
             .collection(FireStorePath.RECORD_DETAIL).get().await()
-        if (detailSnapshot.metadata.isFromCache) throw ExternalException.NetworkError()
+        if (detailSnapshot.metadata.isFromCache) Log.e(TAG, "detailSnapshot is from cache")
         return detailSnapshot
             .documents.map { detailDocument ->
                 detailDocument.toObject(FireStoreRecordDetail::class.java)!!
@@ -148,7 +148,7 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "recordStream snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 val recordList = readAll(snapshot)
                 trySend(recordList)
@@ -189,7 +189,7 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "recordStreamWith(key = $key, value = $value) - snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 val accountRecordList = readAll(snapshot)
                 trySend(accountRecordList)
@@ -234,7 +234,7 @@ class RecordFireStore @Inject constructor(): RecordApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "recordStreamSumOf(key = $key, value = $value, target = $target) - snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 val result = sum(
                     readAllRecordWith(

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/FireStoreGroup.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/FireStoreGroup.kt
@@ -1,7 +1,23 @@
 package com.dirtfy.ppp.data.api.impl.feature.table.firebase
 
+import com.dirtfy.ppp.common.exception.TableException
+import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
+
 data class FireStoreGroup(
     val member: List<Int>?
 ) {
     constructor(): this(null)
+
+    companion object {
+        fun DataTableGroup.convertToFireStoreGroup(): FireStoreGroup {
+            return FireStoreGroup(member = member)
+        }
+    }
+
+    fun convertToDataTableGroup(groupNumber: Int): DataTableGroup {
+        return DataTableGroup(
+            group = groupNumber,
+            member = member ?: throw TableException.MemberLoss()
+        )
+    }
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/TableFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/TableFireStore.kt
@@ -31,7 +31,7 @@ class TableFireStore @Inject constructor(): TableApi, Tagger {
 
         return when (documents.size) {
             1 -> documents[0].id.toInt()
-            0 -> throw TableException.GroupLoss()
+            0 -> throw TableException.GroupLoss() // TODO readTable 에서 이 함수를 호출하는데 이때 다 바꿔야 함 group이 없을 수 있다....
             else -> throw TableException.NonUniqueGroup()
         }
     }
@@ -57,7 +57,7 @@ class TableFireStore @Inject constructor(): TableApi, Tagger {
         return readAllTable(snapshot)
     }
 
-    private fun readAllTable(
+    private fun readAllTable( // order가 있는 것들만 가져온다
         tableSnapshot: QuerySnapshot
     ): List<DataTable> {
         val resultList = mutableListOf<DataTable>()
@@ -128,10 +128,11 @@ class TableFireStore @Inject constructor(): TableApi, Tagger {
                     Log.e(TAG, "tableStream snapshot is from cache")
                     throw ExternalException.NetworkError()
                 }
+                /*
                 if (snapshot.isEmpty) {
                     Log.e(TAG, "tableStream snapshot is empty")
                     throw ExternalException.ServerError()
-                }
+                }*/
 
                 val tableList = readAllTable(snapshot)
                 trySend(tableList)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/TableFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/TableFireStore.kt
@@ -166,7 +166,7 @@ class TableFireStore @Inject constructor(): TableApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "tableStream snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 /*
                 if (snapshot.isEmpty) {
@@ -317,7 +317,7 @@ class TableFireStore @Inject constructor(): TableApi, Tagger {
                 }
                 if (snapshot.metadata.isFromCache) {
                     Log.e(TAG, "orderStream snapshot is from cache")
-                    throw ExternalException.NetworkError()
+//                    throw ExternalException.NetworkError()
                 }
                 val orderList = readAllOrder(snapshot)
                 trySend(orderList)

--- a/app/src/main/java/com/dirtfy/ppp/data/dto/feature/table/DataTable.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/dto/feature/table/DataTable.kt
@@ -2,5 +2,9 @@ package com.dirtfy.ppp.data.dto.feature.table
 
 data class DataTable(
     val number: Int,
-    val group: Int
-)
+    val group: Int = GROUP_NOT_ASSIGNED
+) {
+    companion object {
+        const val GROUP_NOT_ASSIGNED = -1
+    }
+}

--- a/app/src/main/java/com/dirtfy/ppp/data/dto/feature/table/DataTableGroup.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/dto/feature/table/DataTableGroup.kt
@@ -1,6 +1,6 @@
 package com.dirtfy.ppp.data.dto.feature.table
 
 data class DataTableGroup(
-    val group: Int,
-    val member: List<Int>
+    val group: Int = DataTable.GROUP_NOT_ASSIGNED,
+    val member: List<Int> = emptyList()
 )

--- a/app/src/main/java/com/dirtfy/ppp/data/dto/feature/table/DataTableGroup.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/dto/feature/table/DataTableGroup.kt
@@ -1,0 +1,6 @@
+package com.dirtfy.ppp.data.dto.feature.table
+
+data class DataTableGroup(
+    val group: Int,
+    val member: List<Int>
+)

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/AccountBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/AccountBusinessLogic.kt
@@ -23,10 +23,15 @@ class AccountBusinessLogic @Inject constructor(
     }
 
     fun createAccount(
-        number: Int,
+        numberString: String,
         name: String,
         phoneNumber: String
     ) = operate {
+        if(numberString == "")throw AccountException.BlankNumber()
+        else if(name == "")throw AccountException.BlankName()
+        else if(phoneNumber == "")throw AccountException.BlankPhoneNumber()
+
+        val number = numberString.toInt()
         val account = accountApi.let {
             if (it.isSameNumberExist(number))
                 throw AccountException.NonUniqueNumber()

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/AccountBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/AccountBusinessLogic.kt
@@ -69,10 +69,15 @@ class AccountBusinessLogic @Inject constructor(
     }
 
     fun updateAccount(
-        number: Int,
+        numberString: String,
         name: String,
         phoneNumber: String
     ) = operate {
+        if(numberString == "") throw AccountException.BlankNumber()
+        else if(name == "") throw AccountException.BlankName()
+        else if(phoneNumber == "") throw AccountException.BlankPhoneNumber()
+
+        val number = numberString.toInt()
         val account = accountApi.let {
             if (!it.isNumberExist(number))
                 throw AccountException.InvalidNumber()
@@ -125,11 +130,14 @@ class AccountBusinessLogic @Inject constructor(
     fun addAccountRecord(
         accountNumber: Int,
         issuedName: String,
-        difference: Int
+        differenceString: String
     ) = operate {
         if (!accountApi.isNumberExist(accountNumber))
             throw AccountException.InvalidNumber()
+        if(issuedName == "") throw AccountException.BlankIssuedName()
+        if(differenceString == "") throw AccountException.BlankDifference()
 
+        val difference = differenceString.toInt()
         val currentBalance = readBalance(accountNumber)
 
         val result = currentBalance + difference

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
@@ -18,8 +18,12 @@ interface BusinessLogic {
             Log.e("BusinessLogic-exceptionWithRetry: ", "error catch\n $cause")
             when(cause) {
                 is FirebaseFirestoreException -> {
-                    println("FirebaseFirestoreException: Retry attemp ${attempt + 1} ")
-                    attempt <= 3
+                    if (cause.message!!.contains("Unable to resolve host firestore.googleapis.com"))
+                        false
+                    else {
+                        println("FirebaseFirestoreException: Retry attemp ${attempt + 1} ")
+                        attempt <= 3
+                    }
                 }
                 else -> {
                     println("NotFirebaseFirestoreException: Not Retry")
@@ -33,7 +37,11 @@ interface BusinessLogic {
 
             when(e) {
                 is CustomException -> throw e
-                is FirebaseFirestoreException -> throw ExternalException.ServerError()
+                is FirebaseFirestoreException -> {
+                    if (e.message!!.contains("Unable to resolve host firestore.googleapis.com"))
+                        throw ExternalException.NetworkError()
+                    else throw ExternalException.ServerError()
+                }
                 else -> {
                     e.message.let {
                         if (it == null)

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
+import java.net.UnknownHostException
 
 interface BusinessLogic {
 
@@ -30,7 +32,6 @@ interface BusinessLogic {
         Log.e("BusinessLogic-convertExceptionAsCheckedException",
             "error catch\n " +
                     "${e.message}")
-
             when(e) {
                 is CustomException -> throw e
                 is FirebaseFirestoreException -> throw ExternalException.ServerError()
@@ -50,5 +51,4 @@ interface BusinessLogic {
     fun <T> operate(func: suspend () -> T) = flow {
         emit(func())
     }.flowOn(Dispatchers.Default).convertExceptionAsCheckedException()
-
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
@@ -1,5 +1,6 @@
 package com.dirtfy.ppp.data.logic.common
 
+import android.util.Log
 import com.dirtfy.ppp.common.exception.CustomException
 import com.dirtfy.ppp.common.exception.ExternalException
 import com.google.firebase.firestore.FirebaseFirestoreException
@@ -8,13 +9,25 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.retryWhen
 
 interface BusinessLogic {
 
     fun <T> Flow<T>.convertExceptionAsCheckedException() =
-        this.catch { e ->
-            println("BusinessLogic-convertExceptionAsCheckedException: error catch\n " +
-                    "${e.message}")
+    this.retryWhen { cause, attempt ->
+            Log.e("BusinessLogic-exceptionWithRetry: ","error catch\n " + "${cause.message}")
+            when(cause) {
+                is FirebaseFirestoreException -> {
+                    println("FirebaseFirestoreException: Retry attemp ${attempt + 1} ")
+                    attempt <= 3
+                }
+                else -> {
+                    println("NotFirebaseFirestoreException: Not Retry")
+                    false
+                }
+            }
+        }.catch { e ->
+            Log.e("BusinessLogic-convertExceptionAsCheckedException: ","error catch\n " + "${e.message}")
 
             when(e) {
                 is CustomException -> throw e

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
@@ -27,7 +27,9 @@ interface BusinessLogic {
                 }
             }
         }.catch { e ->
-            Log.e("BusinessLogic-convertExceptionAsCheckedException: ","error catch\n " + "${e.message}")
+        Log.e("BusinessLogic-convertExceptionAsCheckedException",
+            "error catch\n " +
+                    "${e.message}")
 
             when(e) {
                 is CustomException -> throw e

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/common/BusinessLogic.kt
@@ -9,15 +9,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
-import java.net.UnknownHostException
 
 interface BusinessLogic {
 
     fun <T> Flow<T>.convertExceptionAsCheckedException() =
     this.retryWhen { cause, attempt ->
-            Log.e("BusinessLogic-exceptionWithRetry: ","error catch\n " + "${cause.message}")
+            Log.e("BusinessLogic-exceptionWithRetry: ", "error catch\n $cause")
             when(cause) {
                 is FirebaseFirestoreException -> {
                     println("FirebaseFirestoreException: Retry attemp ${attempt + 1} ")
@@ -30,8 +28,9 @@ interface BusinessLogic {
             }
         }.catch { e ->
         Log.e("BusinessLogic-convertExceptionAsCheckedException",
-            "error catch\n " +
-                    "${e.message}")
+            "error catch\n $e"
+        )
+
             when(e) {
                 is CustomException -> throw e
                 is FirebaseFirestoreException -> throw ExternalException.ServerError()
@@ -51,4 +50,5 @@ interface BusinessLogic {
     fun <T> operate(func: suspend () -> T) = flow {
         emit(func())
     }.flowOn(Dispatchers.Default).convertExceptionAsCheckedException()
+
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/AccountController.kt
@@ -28,7 +28,6 @@ interface AccountController
         message = "accountRecordList will be automatically updated when nowAccount is updated",
         replaceWith = ReplaceWith("updateNowAccount(account)")
     )
-    fun updateAccountRecordList()
     fun retryUpdateAccountRecordList()
     fun updateNewAccountRecord(newAccountRecord: UiNewAccountRecord)
     suspend fun addRecord()

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountCreateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountCreateControllerImpl.kt
@@ -1,6 +1,7 @@
 package com.dirtfy.ppp.ui.controller.feature.account.impl.viewmodel
 
 import android.util.Log
+import com.dirtfy.ppp.common.exception.AccountException
 import com.dirtfy.ppp.data.logic.AccountBusinessLogic
 import com.dirtfy.ppp.ui.controller.common.converter.common.PhoneNumberFormatConverter.formatPhoneNumber
 import com.dirtfy.ppp.ui.controller.feature.account.AccountCreateController
@@ -33,7 +34,7 @@ class AccountCreateControllerImpl @Inject constructor(
         val (number, name, phoneNumber) = _screenData.value.newAccount
         _screenData.update { it.copy(addAccountState = UiScreenState(UiState.LOADING)) }
         accountBusinessLogic.createAccount(
-            number = number.toInt(),
+            numberString = number,
             name = name,
             phoneNumber = formatPhoneNumber(phoneNumber)
         ).catch { cause ->

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountDetailControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountDetailControllerImpl.kt
@@ -104,7 +104,7 @@ class AccountDetailControllerImpl @Inject constructor(
         accountBusinessLogic.addAccountRecord(
             accountNumber = accountNumber,
             issuedName = issuedName,
-            difference = difference.toInt()
+            differenceString = difference
         ).catch { cause ->
             Log.e(TAG, "addRecord() - addAccountRecord failed \n ${cause.message}")
             _screenData.update {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountUpdateControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountUpdateControllerImpl.kt
@@ -27,7 +27,7 @@ class AccountUpdateControllerImpl @Inject constructor(
 
         _screenData.update { it.copy(updateAccountState = UiScreenState(UiState.LOADING)) }
         accountBusinessLogic.updateAccount(
-            number = number.toInt(),
+            numberString = number,
             name = name,
             phoneNumber = phoneNumber
         ).catch { cause ->

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/account/impl/viewmodel/AccountViewModel.kt
@@ -69,9 +69,7 @@ class AccountViewModel @Inject constructor(
 
 
     @Deprecated("screen state synchronized with repository")
-    override suspend fun updateAccountList() {
-        // TODO 다른 기기에서 어카운트 변경시 어떻게 뷰를 변경할 지 정해야 할 듯
-    }
+    override suspend fun updateAccountList() {}
 
     override fun retryUpdateAccountList() {
         accountListController.retryUpdateAccountList()
@@ -93,9 +91,6 @@ class AccountViewModel @Inject constructor(
         message = "accountRecordList will be automatically updated when nowAccount is updated",
         replaceWith = ReplaceWith("updateNowAccount(account)")
     )
-    override fun updateAccountRecordList() {
-        accountDetailController.updateAccountRecordList(_screenData.value.nowAccount)
-    }
 
     override fun retryUpdateAccountRecordList() {
         accountDetailController.retryUpdateAccountRecordList()

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableController.kt
@@ -20,6 +20,8 @@ interface TableController: Controller<UiTableScreenState, TableController> {
     fun updatePointUse(pointUse: UiPointUse)
 
     fun clickTable(table: UiTable)
+    suspend fun trySetMergeMode()
+    suspend fun escapeFromMergeMode()
     suspend fun mergeTable()
     fun cancelMergeTable()
     suspend fun payTableWithCash()
@@ -31,6 +33,8 @@ interface TableController: Controller<UiTableScreenState, TableController> {
     fun setMode(mode: UiTableMode)
     fun setMenuListState(state: UiScreenState)
     fun setTableListState(state: UiScreenState)
+    fun setTrySetMergeModeState(state: UiScreenState)
+    fun setEscapeFromMergeModeState(state: UiScreenState)
     fun setMergeTableState(state: UiScreenState)
     fun setPayTableWithCashState(state: UiScreenState)
     fun setPayTableWithCardState(state: UiScreenState)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableListController.kt
@@ -1,5 +1,6 @@
 package com.dirtfy.ppp.ui.controller.feature.table
 
+import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.feature.table.UiTableMergeScreenState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTable
@@ -11,6 +12,8 @@ interface TableListController {
 
     @Deprecated("screen state synchronized with repository")
     suspend fun updateTableList()
+    fun getGroupNumber(tableNumber: Int): Int
+    fun getGroup(groupNumber: Int): DataTableGroup
     fun clickTableOnMergeMode(table: UiTable)
     fun clickTableOnMainOrOrderMode(table: UiTable)
     suspend fun mergeTable()

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableListController.kt
@@ -2,13 +2,13 @@ package com.dirtfy.ppp.ui.controller.feature.table
 
 import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.ui.state.common.UiScreenState
-import com.dirtfy.ppp.ui.state.feature.table.UiTableMergeScreenState
+import com.dirtfy.ppp.ui.state.feature.table.UiTableListScreenState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTable
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableMode
 import kotlinx.coroutines.flow.Flow
 
 interface TableListController {
-    val screenData: Flow<UiTableMergeScreenState>
+    val screenData: Flow<UiTableListScreenState>
 
     @Deprecated("screen state synchronized with repository")
     suspend fun updateTableList()
@@ -16,12 +16,16 @@ interface TableListController {
     fun getGroup(groupNumber: Int): DataTableGroup
     fun clickTableOnMergeMode(table: UiTable)
     fun clickTableOnMainOrOrderMode(table: UiTable)
+    suspend fun trySetMergeMode()
+    suspend fun escapeFromMergeMode()
     suspend fun mergeTable()
     fun cancelMergeTable()
-    fun disbandGroup(tableNumber: Int)
+    suspend fun dissolveGroup(groupNumber: Int)
     fun syncTableList()
     fun retryUpdateTableList()
     fun setMode(mode: UiTableMode)
     fun setTableListState(state: UiScreenState)
+    fun setTrySetMergeModeState(state: UiScreenState)
+    fun setEscapeFromMergeModeState(state: UiScreenState)
     fun setMergeTableState(state: UiScreenState)
 }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableListController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableListController.kt
@@ -5,6 +5,7 @@ import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.feature.table.UiTableListScreenState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTable
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableMode
+import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableOrder
 import kotlinx.coroutines.flow.Flow
 
 interface TableListController {
@@ -20,7 +21,7 @@ interface TableListController {
     suspend fun escapeFromMergeMode()
     suspend fun mergeTable()
     fun cancelMergeTable()
-    suspend fun dissolveGroup(groupNumber: Int)
+    suspend fun dissolveGroup(groupNumber: Int, orderList: List<UiTableOrder>)
     fun syncTableList()
     fun retryUpdateTableList()
     fun setMode(mode: UiTableMode)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableOrderController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableOrderController.kt
@@ -1,22 +1,23 @@
 package com.dirtfy.ppp.ui.controller.feature.table
 
+import com.dirtfy.ppp.data.dto.feature.table.DataTable
+import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.feature.table.UiTableOrderScreenState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiPointUse
-import com.dirtfy.ppp.ui.state.feature.table.atom.UiTable
 import kotlinx.coroutines.flow.Flow
 
 interface TableOrderController {
     val screenData: Flow<UiTableOrderScreenState>
 
-    fun updateOrderList(table: UiTable)
+    fun updateOrderList(groupNumber: Int)
     fun retryUpdateOrderList()
     fun updatePointUse(pointUse: UiPointUse)
-    suspend fun payTableWithCash(tableNumber: Int)
-    suspend fun payTableWithCard(tableNumber: Int)
-    suspend fun payTableWithPoint(tableNumber: Int)
-    suspend fun addOrder(tableNumber: Int, name: String, price: String)
-    suspend fun cancelOrder(tableNumber: Int, name: String, price: String)
+    suspend fun payTableWithCash(groupNumber: Int)
+    suspend fun payTableWithCard(groupNumber: Int)
+    suspend fun payTableWithPoint(groupNumber: Int)
+    suspend fun addOrder(selectedTable: DataTable, name: String, price: String)
+    suspend fun cancelOrder(selectedTable: DataTable, name: String, price: String)
     fun setPayTableWithCashState(state: UiScreenState)
     fun setPayTableWithCardState(state: UiScreenState)
     fun setPayTableWithPointState(state: UiScreenState)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableOrderController.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/TableOrderController.kt
@@ -1,7 +1,5 @@
 package com.dirtfy.ppp.ui.controller.feature.table
 
-import com.dirtfy.ppp.data.dto.feature.table.DataTable
-import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.ui.state.common.UiScreenState
 import com.dirtfy.ppp.ui.state.feature.table.UiTableOrderScreenState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiPointUse
@@ -13,11 +11,11 @@ interface TableOrderController {
     fun updateOrderList(groupNumber: Int)
     fun retryUpdateOrderList()
     fun updatePointUse(pointUse: UiPointUse)
-    suspend fun payTableWithCash(groupNumber: Int)
-    suspend fun payTableWithCard(groupNumber: Int)
-    suspend fun payTableWithPoint(groupNumber: Int)
-    suspend fun addOrder(selectedTable: DataTable, name: String, price: String)
-    suspend fun cancelOrder(selectedTable: DataTable, name: String, price: String)
+    suspend fun payTableWithCash()
+    suspend fun payTableWithCard()
+    suspend fun payTableWithPoint()
+    suspend fun addOrder(name: String, price: String)
+    suspend fun cancelOrder(name: String, price: String)
     fun setPayTableWithCashState(state: UiScreenState)
     fun setPayTableWithCardState(state: UiScreenState)
     fun setPayTableWithPointState(state: UiScreenState)

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableListControllerImpl.kt
@@ -7,7 +7,9 @@ import com.dirtfy.ppp.common.exception.TableException
 import com.dirtfy.ppp.data.api.TableApi.Companion.TABLE_GROUP_LOCK_EXPIRE_TIME_MILLISECONDS
 import com.dirtfy.ppp.data.dto.feature.table.DataTable
 import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
+import com.dirtfy.ppp.data.dto.feature.table.DataTableOrder
 import com.dirtfy.ppp.data.logic.TableBusinessLogic
+import com.dirtfy.ppp.ui.controller.common.converter.feature.table.TableAtomConverter.convertToDataTableOrder
 import com.dirtfy.ppp.ui.controller.common.converter.feature.table.TableAtomConverter.convertToUiTable
 import com.dirtfy.ppp.ui.controller.feature.table.TableListController
 import com.dirtfy.ppp.ui.state.common.UiScreenState
@@ -15,6 +17,7 @@ import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.table.UiTableListScreenState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTable
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableMode
+import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableOrder
 import com.dirtfy.tagger.Tagger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -317,8 +320,8 @@ class TableListControllerImpl @Inject constructor(
         selectedTableSet.clear()
     }
 
-    override suspend fun dissolveGroup(groupNumber: Int) {
-        tableBusinessLogic.dissolveGroup(groupNumber)
+    override suspend fun dissolveGroup(groupNumber: Int, orderList: List<UiTableOrder>) {
+        tableBusinessLogic.dissolveGroup(groupNumber, orderList.map { it.convertToDataTableOrder() })
     }
 
     override fun setMode(mode: UiTableMode) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableListControllerImpl.kt
@@ -96,11 +96,28 @@ class TableListControllerImpl @Inject constructor(
     }
 
     private fun _updateTableList(dbTableList: List<DataTable>): List<UiTable> {
-        for (i in dbTableList){
-            Log.d("donggi","updateTableList ${i.group} and ${i.number}")
-        }
         val newList = dbTableList.map { data -> data.convertToUiTable() }.toMutableList()
 
+        val groupColorsMap = dbTableList
+            .map { it.group } //group 번호와 color 매칭
+            .distinct()
+            .associateWith {
+                var groupColor = getRandomColor()
+                while (groupColorSet.contains(groupColor)) {
+                    groupColor = getRandomColor()
+                }
+                groupColorSet.add(groupColor)
+                groupColor
+            }
+
+        for(idx in dbTableList.indices){
+            val dataTable = dbTableList[idx]
+            val color = groupColorsMap[dataTable.group]
+            newList[idx].color = color!!
+            groupMap[dataTable.number] = dataTable.group
+        }
+
+        /*
         val groupMemberCount = MutableList(12) { 0 }
         dbTableList.forEach { table ->
             groupMap[table.number] = table.group
@@ -128,7 +145,7 @@ class TableListControllerImpl @Inject constructor(
                     }
                 }
             }
-
+        */
         setTableListState(UiScreenState(UiState.COMPLETE))
         return tableFormation.map { tableNumber ->
             if (tableNumber == 0)
@@ -143,7 +160,7 @@ class TableListControllerImpl @Inject constructor(
                     // setTableListState(UiScreenState(UiState.FAIL, TableException.NumberLoss()))
 
                     // TODO 일단 더미 테이블로 바꾸기. 오류 처리 방법 논의 필요.
-                    UiTable("?", defaultColor)
+                    UiTable("$tableNumber", defaultColor)
                 } else uiTable
             }
         }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableListControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableListControllerImpl.kt
@@ -163,16 +163,9 @@ class TableListControllerImpl @Inject constructor(
                 UiTable("0", Color.Transparent.value)
             else {
                 Log.d(TAG, "$tableNumber")
-                val uiTable = newList.find { table ->
+                newList.find { table ->
                     table.number == tableNumber.toString()
-                }
-                if (uiTable == null) {
-                    // TODO Transaction 구현 후 주석 해제 해보자.
-                    // setTableListState(UiScreenState(UiState.FAIL, TableException.NumberLoss()))
-
-                    // TODO 일단 더미 테이블로 바꾸기. 오류 처리 방법 논의 필요.
-                    UiTable("$tableNumber", defaultColor)
-                } else uiTable
+                } ?: UiTable("$tableNumber", defaultColor)
             }
         }
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
@@ -2,7 +2,6 @@ package com.dirtfy.ppp.ui.controller.feature.table.impl.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dirtfy.ppp.data.dto.feature.table.DataTable
 import com.dirtfy.ppp.ui.controller.feature.table.TableController
 import com.dirtfy.ppp.ui.controller.feature.table.TableListController
 import com.dirtfy.ppp.ui.controller.feature.table.TableMenuController
@@ -27,8 +26,6 @@ class TableViewModel @Inject constructor(
     private val orderController: TableOrderController,
     private val menuController: TableMenuController
 ): ViewModel(), TableController, Tagger {
-
-    private lateinit var selectedDataTable: DataTable
 
     override val screenData: StateFlow<UiTableScreenState>
         = menuController.screenData
@@ -70,9 +67,9 @@ class TableViewModel @Inject constructor(
     }
 
     override fun updateOrderList(table: UiTable) {
-        selectedDataTable = DataTable(table.number.toInt(), listController.getGroupNumber(table.number.toInt()))
-        println(selectedDataTable.toString())
-        orderController.updateOrderList(selectedDataTable.group)
+        val groupNumber = listController.getGroupNumber(table.number.toInt())
+        println("table${table.number} is group$groupNumber")
+        orderController.updateOrderList(groupNumber)
     }
 
     override fun retryUpdateOrderList() {
@@ -114,26 +111,26 @@ class TableViewModel @Inject constructor(
     }
 
     override suspend fun payTableWithCash() {
-        orderController.payTableWithCash(selectedDataTable.group)
+        orderController.payTableWithCash()
         disbandGroup()
     }
 
     override suspend fun payTableWithCard() {
-        orderController.payTableWithCard(selectedDataTable.group)
+        orderController.payTableWithCard()
         disbandGroup()
     }
 
     override suspend fun payTableWithPoint() {
-        orderController.payTableWithPoint(selectedDataTable.group)
+        orderController.payTableWithPoint()
         disbandGroup()
     }
 
     override suspend fun addOrder(name: String, price: String) {
-        orderController.addOrder(selectedDataTable, name, price)
+        orderController.addOrder(name, price)
     }
 
     override suspend fun cancelOrder(name: String, price: String) {
-        orderController.cancelOrder(selectedDataTable, name, price)
+        orderController.cancelOrder(name, price)
     }
 
     override fun setMode(mode: UiTableMode) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
@@ -37,6 +37,8 @@ class TableViewModel @Inject constructor(
                 sourceTableList = listScreenData.sourceTableList,
                 mode = listScreenData.mode,
                 tableListState = listScreenData.tableListState,
+                trySetMergeModeState = listScreenData.trySetMergeModeState,
+                escapeFromMergeModeState = listScreenData.escapeFromMergeModeState,
                 mergeTableState = listScreenData.mergeTableState
             )
         }.combine(orderController.screenData) { state, orderScreenData ->
@@ -96,6 +98,14 @@ class TableViewModel @Inject constructor(
         }
     }
 
+    override suspend fun trySetMergeMode() {
+        listController.trySetMergeMode()
+    }
+
+    override suspend fun escapeFromMergeMode() {
+        listController.escapeFromMergeMode()
+    }
+
     override suspend fun mergeTable() {
         listController.mergeTable()
     }
@@ -143,6 +153,14 @@ class TableViewModel @Inject constructor(
 
     override fun setTableListState(state: UiScreenState) {
         listController.setTableListState(state)
+    }
+
+    override fun setTrySetMergeModeState(state: UiScreenState) {
+        listController.setTrySetMergeModeState(state)
+    }
+
+    override fun setEscapeFromMergeModeState(state: UiScreenState) {
+        listController.setEscapeFromMergeModeState(state)
     }
 
     override fun setMergeTableState(state: UiScreenState) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
@@ -2,6 +2,7 @@ package com.dirtfy.ppp.ui.controller.feature.table.impl.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dirtfy.ppp.data.dto.feature.table.DataTable
 import com.dirtfy.ppp.ui.controller.feature.table.TableController
 import com.dirtfy.ppp.ui.controller.feature.table.TableListController
 import com.dirtfy.ppp.ui.controller.feature.table.TableMenuController
@@ -27,7 +28,7 @@ class TableViewModel @Inject constructor(
     private val menuController: TableMenuController
 ): ViewModel(), TableController, Tagger {
 
-    private var selectedTableNumber: Int = 0
+    private lateinit var selectedDataTable: DataTable
 
     override val screenData: StateFlow<UiTableScreenState>
         = menuController.screenData
@@ -69,9 +70,9 @@ class TableViewModel @Inject constructor(
     }
 
     override fun updateOrderList(table: UiTable) {
-        selectedTableNumber = table.number.toInt()
-        println(selectedTableNumber.toString())
-        orderController.updateOrderList(table)
+        selectedDataTable = DataTable(table.number.toInt(), listController.getGroupNumber(table.number.toInt()))
+        println(selectedDataTable.toString())
+        orderController.updateOrderList(selectedDataTable.group)
     }
 
     override fun retryUpdateOrderList() {
@@ -113,26 +114,26 @@ class TableViewModel @Inject constructor(
     }
 
     override suspend fun payTableWithCash() {
-        orderController.payTableWithCash(selectedTableNumber)
+        orderController.payTableWithCash(selectedDataTable.group)
         disbandGroup()
     }
 
     override suspend fun payTableWithCard() {
-        orderController.payTableWithCard(selectedTableNumber)
+        orderController.payTableWithCard(selectedDataTable.group)
         disbandGroup()
     }
 
     override suspend fun payTableWithPoint() {
-        orderController.payTableWithPoint(selectedTableNumber)
+        orderController.payTableWithPoint(selectedDataTable.group)
         disbandGroup()
     }
 
     override suspend fun addOrder(name: String, price: String) {
-        orderController.addOrder(selectedTableNumber, name, price)
+        orderController.addOrder(selectedDataTable, name, price)
     }
 
     override suspend fun cancelOrder(name: String, price: String) {
-        orderController.cancelOrder(selectedTableNumber, name, price)
+        orderController.cancelOrder(selectedDataTable, name, price)
     }
 
     override fun setMode(mode: UiTableMode) {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
@@ -118,7 +118,7 @@ class TableViewModel @Inject constructor(
 
     private fun disbandGroup() {
         //listController.disbandGroup(selectedTableNumber)
-        setMode(UiTableMode.Main)
+        listController.setMode(UiTableMode.Main)
     }
 
     override suspend fun payTableWithCash() {

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableViewModel.kt
@@ -35,6 +35,7 @@ class TableViewModel @Inject constructor(
                 menuListState = menuScreenState.menuListState,
                 tableList = listScreenData.tableList,
                 sourceTableList = listScreenData.sourceTableList,
+                timeLeftUntilEndOfMergeMode = listScreenData.timeLeftUntilEndOfMergeMode,
                 mode = listScreenData.mode,
                 tableListState = listScreenData.tableListState,
                 trySetMergeModeState = listScreenData.trySetMergeModeState,

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableListScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableListScreenState.kt
@@ -8,6 +8,7 @@ import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableMode
 data class UiTableListScreenState(
     val tableList: List<UiTable> = emptyList(),
     val sourceTableList: List<UiTable> = emptyList(),
+    val timeLeftUntilEndOfMergeMode: String = "",
     val mode: UiTableMode = UiTableMode.Main,
 
     val tableListState: UiScreenState = UiScreenState(),

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableListScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableListScreenState.kt
@@ -5,11 +5,13 @@ import com.dirtfy.ppp.ui.state.common.UiState
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTable
 import com.dirtfy.ppp.ui.state.feature.table.atom.UiTableMode
 
-data class UiTableMergeScreenState(
+data class UiTableListScreenState(
     val tableList: List<UiTable> = emptyList(),
     val sourceTableList: List<UiTable> = emptyList(),
     val mode: UiTableMode = UiTableMode.Main,
 
     val tableListState: UiScreenState = UiScreenState(),
+    val trySetMergeModeState: UiScreenState = UiScreenState(UiState.COMPLETE),
+    val escapeFromMergeModeState: UiScreenState = UiScreenState(UiState.COMPLETE),
     val mergeTableState: UiScreenState = UiScreenState(UiState.COMPLETE),
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableScreenState.kt
@@ -16,7 +16,7 @@ data class UiTableScreenState(
 
     val orderTotalPrice: String = "",
     val pointUse: UiPointUse = UiPointUse(),
-
+    val timeLeftUntilEndOfMergeMode: String = "",
     val mode: UiTableMode = UiTableMode.Main,
 
     val tableListState: UiScreenState = UiScreenState(),

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableScreenState.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/UiTableScreenState.kt
@@ -22,6 +22,8 @@ data class UiTableScreenState(
     val tableListState: UiScreenState = UiScreenState(),
     val orderListState: UiScreenState = UiScreenState(),
     val menuListState: UiScreenState = UiScreenState(),
+    val trySetMergeModeState: UiScreenState = UiScreenState(UiState.COMPLETE),
+    val escapeFromMergeModeState: UiScreenState = UiScreenState(UiState.COMPLETE),
     val mergeTableState: UiScreenState = UiScreenState(UiState.COMPLETE),
     val payTableWithCashState: UiScreenState = UiScreenState(UiState.COMPLETE),
     val payTableWithCardState: UiScreenState = UiScreenState(UiState.COMPLETE),

--- a/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/atom/UiTable.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/state/feature/table/atom/UiTable.kt
@@ -2,5 +2,5 @@ package com.dirtfy.ppp.ui.state.feature.table.atom
 
 data class UiTable(
     val number: String,
-    val color: ULong
+    var color: ULong
 )

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/MainActivity.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/MainActivity.kt
@@ -1,7 +1,11 @@
 package com.dirtfy.ppp.ui.view
 
 import android.content.res.Configuration
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
+import android.os.Looper
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material.icons.Icons
@@ -15,9 +19,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.navigation.compose.rememberNavController
+import com.dirtfy.ppp.R
 import com.dirtfy.ppp.ui.view.phone.PhoneScreen
 import com.dirtfy.ppp.ui.view.tablet.TabletScreen
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -49,6 +57,8 @@ class MainActivity: ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        startObservingNetworkConnection()
 
         setContent {
             val navController = rememberNavController()
@@ -96,6 +106,35 @@ class MainActivity: ComponentActivity() {
                         }
                     }
                 )
+            }
+        }
+    }
+
+    private fun startObservingNetworkConnection() {
+        CoroutineScope(Dispatchers.IO).launch {
+            val manager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+
+            Looper.prepare()
+            while (true) {
+                val actNetwork = manager.activeNetwork
+                var isConnected = false
+                if (actNetwork != null) {
+                    val caps = manager.getNetworkCapabilities(actNetwork)
+                    if (caps != null) {
+                        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+                            || caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI))
+                            isConnected = true
+                    }
+                }
+                if (!isConnected) {
+                    Toast.makeText(
+                        this@MainActivity,
+                        resources.getText(R.string.internet_connection_fail),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+
+                Thread.sleep(5000)
             }
         }
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/menu/MenuScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/menu/MenuScreen.kt
@@ -60,8 +60,7 @@ class MenuScreen @Inject constructor(
         )
         Component.HandleUiStateDialog(
             uiState = screen.deleteMenuState,
-            onDismissRequest = { controller.setDeleteMenuState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 이후 구현
+            onDismissRequest = { controller.setDeleteMenuState(UiScreenState(UiState.COMPLETE)) }
         )
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/record/RecordScreen.kt
@@ -63,7 +63,7 @@ class RecordScreen @Inject constructor(
         Component.HandleUiStateDialog(
             uiState = screenData.nowRecordState,
             onDismissRequest = { controller.setNowRecordState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 해결 후 실행 nowRecordState
+            onRetryAction = null
         )
 
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
@@ -68,10 +68,16 @@ class TableScreen @Inject constructor(
         LaunchedEffect(key1 = controller) {
             controller.updateTableList()
         }
+
+        Component.HandleUiStateDialog(
+            uiState = screenData.trySetMergeModeState,
+            onDismissRequest = { controller.setTrySetMergeModeState(UiScreenState(UiState.COMPLETE)) },
+            onRetryAction = { controller.request { trySetMergeMode() } }
+        )
         Component.HandleUiStateDialog(
             uiState = screenData.mergeTableState,
             onDismissRequest = { controller.setMergeTableState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = {controller.request { mergeTable() }}
+            onRetryAction = { controller.request { mergeTable() } }
         )
 
         Component.HandleUiStateDialog(
@@ -122,9 +128,9 @@ class TableScreen @Inject constructor(
                     updateMenuList()
                 }
             },
-            onMergeClick = {controller.setMode(UiTableMode.Merge)},
+            onMergeClick = { controller.request { trySetMergeMode() } },
             onMergeOkClick = { controller.request { mergeTable() } },
-            onMergeCancelClick = { controller.cancelMergeTable() },
+            onMergeCancelClick = { controller.request { escapeFromMergeMode() } },
             onCashClick = { controller.request { payTableWithCash() } },
             onCardClick = { controller.request { payTableWithCard() } },
             onPointClick = { controller.setMode(UiTableMode.PointUse) },

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
@@ -119,6 +119,7 @@ class TableScreen @Inject constructor(
             totalPrice = screenData.orderTotalPrice,
             pointUse = screenData.pointUse,
             mode = screenData.mode,
+            timeLeftUntilEndOfMergeMode = screenData.timeLeftUntilEndOfMergeMode,
             addOrderState = screenData.addOrderState,
             cancelOrderState = screenData.cancelOrderState,
             onTableClick = {
@@ -183,6 +184,7 @@ class TableScreen @Inject constructor(
         totalPrice: String,
         pointUse: UiPointUse,
         mode: UiTableMode,
+        timeLeftUntilEndOfMergeMode: String,
         addOrderState: UiScreenState,
         cancelOrderState: UiScreenState,
         onTableClick: (UiTable) -> Unit,
@@ -223,6 +225,7 @@ class TableScreen @Inject constructor(
                         TableLayout(
                             tableList = tableList,
                             mode = mode,
+                            timeLeftUntilEndOfMergeMode = timeLeftUntilEndOfMergeMode,
                             onTableClick = onTableClick,
                             onMergeClick = onMergeClick,
                             onMergeOkClick = onMergeOkClick,
@@ -298,6 +301,7 @@ class TableScreen @Inject constructor(
     fun TableLayout(
         tableList: List<UiTable>,
         mode: UiTableMode,
+        timeLeftUntilEndOfMergeMode: String,
         onTableClick: (UiTable) -> Unit,
         onMergeClick: () -> Unit,
         onMergeOkClick: () -> Unit,
@@ -329,11 +333,12 @@ class TableScreen @Inject constructor(
                 }
                 Box(modifier = Modifier
                     .constrainAs(mergeButtonRow){
-                        bottom.linkTo(tables.bottom)
+                        top.linkTo(tables.bottom)
                     }
                 ) {
                     MergeButtonLayout(
                         mode = mode,
+                        timeLeftUntilEndOfMergeMode = timeLeftUntilEndOfMergeMode,
                         onMergeClick = onMergeClick,
                         onMergeOkClick = onMergeOkClick,
                         onMergeCancelClick = onMergeCancelClick
@@ -346,6 +351,7 @@ class TableScreen @Inject constructor(
     @Composable
     fun MergeButtonLayout(
         mode: UiTableMode,
+        timeLeftUntilEndOfMergeMode: String,
         onMergeClick: () -> Unit,
         onMergeOkClick: () -> Unit,
         onMergeCancelClick: () -> Unit
@@ -353,6 +359,7 @@ class TableScreen @Inject constructor(
         if (mode == UiTableMode.Merge) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(text = stringResource(R.string.select_table), style = MaterialTheme.typography.bodyMedium)
+                Text(text = timeLeftUntilEndOfMergeMode, style = MaterialTheme.typography.bodyMedium)
                 Row {
                     Button(onClick = onMergeOkClick ) {
                         Text(text = stringResource(R.string.ok))

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
@@ -93,13 +93,13 @@ class TableScreen @Inject constructor(
         Component.HandleUiStateDialog(
             uiState = screenData.addOrderState,
             onDismissRequest = { controller.setAddOrderState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 구현후 수정 예정
+            onRetryAction = null
         )
 
         Component.HandleUiStateDialog(
             uiState = screenData.cancelOrderState,
             onDismissRequest = { controller.setCancelOrderState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 구현후 수정 예정
+            onRetryAction = null
         )
 
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordDetailScreen.kt
@@ -56,7 +56,7 @@ class RecordDetailScreen @Inject constructor(
         Component.HandleUiStateDialog(
             uiState = screenData.nowRecordState,
             onDismissRequest = { controller.setNowRecordState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO RetryStream 해결 후 실행
+            onRetryAction = null
         )
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/record/RecordScreen.kt
@@ -62,7 +62,7 @@ class RecordScreen @Inject constructor(
         Component.HandleUiStateDialog(
             uiState = screenData.nowRecordState,
             onDismissRequest = { controller.setNowRecordState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 해결 후 실행 nowRecordState
+            onRetryAction = null
         )
 
     }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
@@ -124,6 +124,7 @@ class TableScreen @Inject constructor(
             totalPrice = screenData.orderTotalPrice,
             pointUse = screenData.pointUse,
             mode = screenData.mode,
+            timeLeftUntilEndOfMergeMode = screenData.timeLeftUntilEndOfMergeMode,
             addOrderState = screenData.addOrderState,
             cancelOrderState = screenData.cancelOrderState,
             onTableClick = {
@@ -188,6 +189,7 @@ class TableScreen @Inject constructor(
         totalPrice: String,
         pointUse: UiPointUse,
         mode: UiTableMode,
+        timeLeftUntilEndOfMergeMode: String,
         addOrderState: UiScreenState,
         cancelOrderState: UiScreenState,
         onTableClick: (UiTable) -> Unit,
@@ -228,6 +230,7 @@ class TableScreen @Inject constructor(
                         TableLayout(
                             tableList = tableList,
                             mode = mode,
+                            timeLeftUntilEndOfMergeMode = timeLeftUntilEndOfMergeMode,
                             onTableClick = onTableClick,
                             onMergeClick = onMergeClick,
                             onMergeOkClick = onMergeOkClick,
@@ -303,6 +306,7 @@ class TableScreen @Inject constructor(
     fun TableLayout(
         tableList: List<UiTable>,
         mode: UiTableMode,
+        timeLeftUntilEndOfMergeMode: String,
         onTableClick: (UiTable) -> Unit,
         onMergeClick: () -> Unit,
         onMergeOkClick: () -> Unit,
@@ -334,11 +338,12 @@ class TableScreen @Inject constructor(
                 }
                 Box(modifier = Modifier
                     .constrainAs(mergeButtonRow){
-                        bottom.linkTo(tables.bottom)
+                        top.linkTo(tables.bottom)
                     }
                 ) {
                     MergeButtonLayout(
                         mode = mode,
+                        timeLeftUntilEndOfMergeMode = timeLeftUntilEndOfMergeMode,
                         onMergeClick = onMergeClick,
                         onMergeOkClick = onMergeOkClick,
                         onMergeCancelClick = onMergeCancelClick
@@ -351,6 +356,7 @@ class TableScreen @Inject constructor(
     @Composable
     fun MergeButtonLayout(
         mode: UiTableMode,
+        timeLeftUntilEndOfMergeMode: String,
         onMergeClick: () -> Unit,
         onMergeOkClick: () -> Unit,
         onMergeCancelClick: () -> Unit
@@ -358,6 +364,7 @@ class TableScreen @Inject constructor(
         if (mode == UiTableMode.Merge) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(text = stringResource(R.string.select_table), style = MaterialTheme.typography.bodyMedium)
+                Text(text = timeLeftUntilEndOfMergeMode, style = MaterialTheme.typography.bodyMedium)
                 Row {
                     Button(onClick = onMergeOkClick ) {
                         Text(text = stringResource(R.string.ok))

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
@@ -68,10 +68,21 @@ class TableScreen @Inject constructor(
         LaunchedEffect(key1 = controller) {
             controller.updateTableList()
         }
+
+        Component.HandleUiStateDialog(
+            uiState = screenData.trySetMergeModeState,
+            onDismissRequest = { controller.setTrySetMergeModeState(UiScreenState(UiState.COMPLETE)) },
+            onRetryAction = { controller.request { trySetMergeMode() } }
+        )
+        Component.HandleUiStateDialog(
+            uiState = screenData.escapeFromMergeModeState,
+            onDismissRequest = { controller.setEscapeFromMergeModeState(UiScreenState(UiState.COMPLETE)) },
+            onRetryAction = { controller.request { escapeFromMergeMode() } }
+        )
         Component.HandleUiStateDialog(
             uiState = screenData.mergeTableState,
             onDismissRequest = { controller.setMergeTableState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = {controller.request { mergeTable() }}
+            onRetryAction = {controller.request { mergeTable() } }
         )
 
         Component.HandleUiStateDialog(
@@ -122,9 +133,9 @@ class TableScreen @Inject constructor(
                     updateMenuList()
                 }
             },
-            onMergeClick = {controller.setMode(UiTableMode.Merge)},
+            onMergeClick = { controller.request { trySetMergeMode() } },
             onMergeOkClick = { controller.request { mergeTable() } },
-            onMergeCancelClick = { controller.cancelMergeTable() },
+            onMergeCancelClick = { controller.request { escapeFromMergeMode() } },
             onCashClick = { controller.request { payTableWithCash() } },
             onCardClick = { controller.request { payTableWithCard() } },
             onPointClick = { controller.setMode(UiTableMode.PointUse) },

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
@@ -93,13 +93,13 @@ class TableScreen @Inject constructor(
         Component.HandleUiStateDialog(
             uiState = screenData.addOrderState,
             onDismissRequest = { controller.setAddOrderState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 구현후 수정 예정
+            onRetryAction = null
         )
 
         Component.HandleUiStateDialog(
             uiState = screenData.cancelOrderState,
             onDismissRequest = { controller.setCancelOrderState(UiScreenState(UiState.COMPLETE)) },
-            onRetryAction = { } // TODO Retry 구현후 수정 예정
+            onRetryAction = null
         )
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,5 +43,6 @@
     <!--Component-->
     <string name="retry">재시도</string>
     <string name="unknown_error">알 수 없는 오류</string>
+    <string name="internet_connection_fail">네트워크에 연결되어있지 않습니다.</string>
 
 </resources>


### PR DESCRIPTION
### #85 Table 병합 및 해체, 결제, 주문 추가/삭제 기능의 성능 개선

1. transaction을 도입하여 한번에 비동기 요청을 보내도록 수정.
2. controller layer에 있는 정보는 서버로부터 읽어오지 않고 controller layer에서 가져오도록 수정.
3. #46 
table db 구조 수정: 1~11번 그룹이 이미 존재하고, 그룹 2개를 병합하던 구조
-> 그룹이 없고, merge를 하면 병합되는 table number를 넣은 새로운 그룹을 생성. 
  이제 merge 해야 주문을 추가할 수 있다.
4. 구조의 수정으로 인해, 그룹 병합, 해체 시
member list에서 table 하나하나 지우고 넣고 하던 걸 한꺼번에 지우도록 개선.

### #39 Table 병합에 Lock 도입
이제 하나의 디바이스만 (Table 병합/Table 결제+Table 해체) 기능을 사용할 수 있음.
즉 동시에 여러 디바이스가 테이블 그룹을 변화시키는 작업을 수행할 수 없음.
문제점 존재. #96 참고...

> 지금 Table merge에 lock 걸다가 문득
merge 모드 상태에서 폰이 꺼지면 서버에 lock field 값이 변경이 없고,
그럼 모든 디바이스가 lock을 가져갈 수 없는 상황이 된다는 문제점을 발견함.

(2024.12.07 15:40) table merge lock 마지막 활용 timestamp를 유지하여 문제점 해결.

### network error 판단 구조 변경

setPersistenceEnable(false)를 사용하여 캐시를 쓰지 않도록 막음.
그런데 network 연결 안된상태로 DB get요청하면 캐시에서 읽어올려 한다.
캐시에 아무것도 쓰지 않도록 해놓았기 때문에 이 경우 network error 던지게 해놨었음.

근데 가끔 network 연결 돼있는데 network error가 발생했고,
가끔 먼저 캐시에서 들고와서 띄우고, network 요청을 보내 변경사항을 받아온다고 판단.

그래서 캐시에서 들고와서 띄우는 건 허용하기로 하고, network error 던지지 않도록 변경.
즉 DB read 요청은 캐시에서 오든 서버에서 오든 허용.

DB에 write 요청은 
캐시를 쓰면 이런 요청이있었다 라는걸 캐시에 써놨다가 네트워크 연결되면 다 한번에 보내는데, 
캐시 안쓰게 해놔서 이 기능이 꺼짐.

그래서 write 요청의 경우 operate 함수에서 catch 된 Exception의 종류와 메시지를 기반으로
Network error를 던지도록 구현함.

이렇게 하면 stream을 못가져왔을때도 Exception을 throw하지 않기 때문에 문제가 있다고 판단.
MainActivity에서 Coroutine block을 하나 생성, 지속적으로 network connection을 감지하도록 하고,
network 연결이 끊어진 상태라면 Toast를 띄우도록 구현함.