### PR TITLE
Generic Transaction Type

### DIFF
--- a/app/src/main/java/com/dirtfy/ppp/common/di/DataModule.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/di/DataModule.kt
@@ -39,12 +39,12 @@ class DataModule {
     }
 
     @Provides
-    fun providesRecordApi(): RecordApi {
+    fun providesRecordApi(): RecordApi<Transaction> {
         return providesApiProvider().recordApi
     }
 
     @Provides
-    fun providesTableApi(): TableApi {
+    fun providesTableApi(): TableApi<Transaction> {
         return providesApiProvider().tableApi
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/RecordApi.kt
@@ -5,10 +5,10 @@ import com.dirtfy.ppp.data.dto.feature.record.DataRecordDetail
 import com.google.firebase.firestore.Transaction
 import kotlinx.coroutines.flow.Flow
 
-interface RecordApi {
+interface RecordApi <TransactionType> {
 
     suspend fun create(record: DataRecord, detailList: List<DataRecordDetail>): DataRecord
-    fun create(record: DataRecord, detailList: List<DataRecordDetail>, transaction: Transaction): DataRecord
+    fun create(record: DataRecord, detailList: List<DataRecordDetail>, transaction: TransactionType): DataRecord
     suspend fun read(id: Int): DataRecord
     suspend fun readAll(): List<DataRecord>
     suspend fun <ValueType> readRecordWith(key: String, value: ValueType): List<DataRecord>

--- a/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/TableApi.kt
@@ -3,38 +3,37 @@ package com.dirtfy.ppp.data.api
 import com.dirtfy.ppp.data.dto.feature.table.DataTable
 import com.dirtfy.ppp.data.dto.feature.table.DataTableGroup
 import com.dirtfy.ppp.data.dto.feature.table.DataTableOrder
-import com.google.firebase.firestore.Transaction
 import kotlinx.coroutines.flow.Flow
 
-interface TableApi {
+interface TableApi <TransactionType> {
     companion object {
         const val TABLE_GROUP_LOCK_EXPIRE_TIME_MILLISECONDS = 30000L // 30초
     }
 
-    fun createGroup(group: DataTableGroup, transaction: Transaction): DataTableGroup
-    fun deleteGroup(groupNumber: Int, orderList: List<DataTableOrder>, transaction: Transaction)
+    fun createGroup(group: DataTableGroup, transaction: TransactionType): DataTableGroup
+    fun deleteGroup(groupNumber: Int, orderList: List<DataTableOrder>, transaction: TransactionType)
     suspend fun readTable(tableNumber: Int): DataTable
     suspend fun readAllGroupedTable(): List<DataTable>
-    fun checkTableGroupLock(transaction: Transaction)
-    fun getTableGroupLock(transaction: Transaction)
-    fun releaseTableGroupLock(transaction: Transaction)
+    fun checkTableGroupLock(transaction: TransactionType)
+    fun getTableGroupLock(transaction: TransactionType)
+    fun releaseTableGroupLock(transaction: TransactionType)
     fun tableStream(): Flow<List<DataTable>>
 
     suspend fun readOrder(groupNumber: Int, menuName: String): DataTableOrder
-    fun readOrder(groupNumber: Int, menuName: String, transaction: Transaction): DataTableOrder
+    fun readOrder(groupNumber: Int, menuName: String, transaction: TransactionType): DataTableOrder
     suspend fun readAllOrder(groupNumber: Int): List<DataTableOrder>
     suspend fun setOrder(groupNumber: Int, order: DataTableOrder)
-    fun setOrder(groupNumber: Int, order: DataTableOrder, transaction: Transaction)
-    fun incrementOrder(groupNumber: Int, menuName: String, transaction: Transaction)
-    fun decrementOrder(groupNumber: Int, menuName: String, transaction: Transaction)
+    fun setOrder(groupNumber: Int, order: DataTableOrder, transaction: TransactionType)
+    fun incrementOrder(groupNumber: Int, menuName: String, transaction: TransactionType)
+    fun decrementOrder(groupNumber: Int, menuName: String, transaction: TransactionType)
     suspend fun deleteOrder(groupNumber: Int, menuName: String)
-    fun deleteOrder(groupNumber: Int, menuName: String, transaction: Transaction)
+    fun deleteOrder(groupNumber: Int, menuName: String, transaction: TransactionType)
     suspend fun deleteAllOrder(groupNumber: Int)
-    fun deleteOrders(groupNumber: Int, orderList: List<DataTableOrder>, transaction: Transaction)
+    fun deleteOrders(groupNumber: Int, orderList: List<DataTableOrder>, transaction: TransactionType)
     fun orderStream(groupNumber: Int): Flow<List<DataTableOrder>>
 
     suspend fun isGroupExist(groupNumber: Int): Boolean
-    fun isGroupExist(groupNumber: Int, transaction: Transaction): Boolean
+    fun isGroupExist(groupNumber: Int, transaction: TransactionType): Boolean
     suspend fun isOrderExist(groupNumber: Int, menuName: String): Boolean
-    fun isOrderExist(groupNumber: Int, menuName: String, transaction: Transaction): Boolean
+    fun isOrderExist(groupNumber: Int, menuName: String, transaction: TransactionType): Boolean
 }

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/record/firebase/RecordFireStore.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
-class RecordFireStore @Inject constructor(): RecordApi, Tagger {
+class RecordFireStore @Inject constructor(): RecordApi<Transaction>, Tagger {
 
     private val recordRef = Firebase.firestore.collection(FireStorePath.RECORD)
     private val recordIdRef = Firebase.firestore.document(FireStorePath.RECORD_ID_COUNT)

--- a/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/TableFireStore.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/api/impl/feature/table/firebase/TableFireStore.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.tasks.await
 import java.util.Date
 import javax.inject.Inject
 
-class TableFireStore @Inject constructor(): TableApi, Tagger {
+class TableFireStore @Inject constructor(): TableApi<Transaction>, Tagger {
 
     private val tableRef = Firebase.firestore.collection(FireStorePath.TABLE)
     private val mergeLockRef = Firebase.firestore.document(FireStorePath.TABLE_GROUP_LOCK)

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/RecordBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/RecordBusinessLogic.kt
@@ -1,5 +1,6 @@
 package com.dirtfy.ppp.data.logic
 
+import android.view.SurfaceControl.Transaction
 import com.dirtfy.ppp.data.api.RecordApi
 import com.dirtfy.ppp.data.dto.feature.record.DataRecord
 import com.dirtfy.ppp.data.logic.common.BusinessLogic
@@ -7,7 +8,7 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class RecordBusinessLogic @Inject constructor(
-    private val repository: RecordApi
+    private val repository: RecordApi<Transaction> // TODO com.google.firebase.firestore.Transaction 숨기기
 ): BusinessLogic {
 
     fun readRecord(id: Int) = operate {

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
@@ -17,8 +17,8 @@ import com.google.firebase.firestore.Transaction
 import javax.inject.Inject
 
 class TableBusinessLogic @Inject constructor(
-    private val tableApi: TableApi,
-    private val recordApi: RecordApi,
+    private val tableApi: TableApi<Transaction>,
+    private val recordApi: RecordApi<Transaction>,
     private val transactionManager: TransactionManager<Transaction> // TODO com.google.firebase.firestore.Transaction 숨기기
 ): BusinessLogic {
 


### PR DESCRIPTION
어떻게 해야 Transaction 클래스를 완전히 숨길 수 있을지 모르겠다.
현재는 interface 상에서 Transaction 클래스의 타입을 generic 으로 만들고, 구현체에서 타입을 지정함.
완전히 숨기지는 못하였고,
하위 Business Logic에 Api 클래스를 DI하는 과정에만 드러나도록 변경해놓은 상태다.