### PR TITLE
Number Input Exception Handling

### DIFF
--- a/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
+++ b/app/src/main/java/com/dirtfy/ppp/common/exception/TableException.kt
@@ -4,6 +4,9 @@ sealed class TableException(
     massage: String
 ): CustomException(massage) {
 
+    class BlankAccountNumber: TableException("account number can not be a blank")
+    class InvalidAccountNumber: TableException("it's invalid account number")
+
     class TableLockPreempted: TableException("simultaneous group edition is not allowed")
     class IllegalMergeModeSet: TableException("setMode(Merge) is not allowed. use trySetMergeMode()")
 

--- a/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
+++ b/app/src/main/java/com/dirtfy/ppp/data/logic/TableBusinessLogic.kt
@@ -175,11 +175,14 @@ class TableBusinessLogic @Inject constructor(
 
     fun payTableWithPoint(
         groupNumber: Int,
-        accountNumber: Int,
+        accountNumberString: String,
         issuedName: String,
         orderList: List<DataTableOrder>
     ) = operate {
-        val nowBalance = recordApi.readSumOf("type", "$accountNumber", "income")
+        if (accountNumberString == "")
+            throw TableException.BlankAccountNumber()
+
+        val nowBalance = recordApi.readSumOf("type", accountNumberString, "income")
         val totalPrice = orderList.calcTotalPrice()
 
         if (nowBalance < totalPrice)
@@ -189,7 +192,7 @@ class TableBusinessLogic @Inject constructor(
             tableApi.checkTableGroupLock(transaction)
             val payment = payTable(
                 orderList = orderList,
-                type = "$accountNumber",
+                type = accountNumberString,
                 issuedName = issuedName,
                 transaction = transaction
             )

--- a/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableOrderControllerImpl.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/controller/feature/table/impl/viewmodel/TableOrderControllerImpl.kt
@@ -139,14 +139,14 @@ class TableOrderControllerImpl @Inject constructor(
 
     private suspend fun _payTableWithPoint(
         groupNumber: Int,
-        accountNumber: Int,
+        accountNumberString: String,
         issuedName: String,
         orderList: List<UiTableOrder>
     ) {
         _screenData.update { it.copy(payTableWithPointState = UiScreenState(UiState.LOADING)) }
         tableBusinessLogic.payTableWithPoint(
             groupNumber = groupNumber,
-            accountNumber = accountNumber,
+            accountNumberString = accountNumberString,
             issuedName = issuedName,
             orderList = orderList.map { it.convertToDataTableOrder() }
         ).catch { cause ->
@@ -156,7 +156,7 @@ class TableOrderControllerImpl @Inject constructor(
         }
     }
     override suspend fun payTableWithPoint() {
-        val accountNumber = _screenData.value.pointUse.accountNumber.toInt()
+        val accountNumber = _screenData.value.pointUse.accountNumber
         val issuedName = _screenData.value.pointUse.userName
         val orderList = _screenData.value.orderList
         _payTableWithPoint(

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/Component.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/Component.kt
@@ -69,7 +69,7 @@ object Component {
                         singleLine = true,
                         modifier = Modifier.widthIn(200.dp, 400.dp),
                         keyboardOptions = KeyboardOptions.Default.copy(
-                            keyboardType = if (isNumber) KeyboardType.Number else KeyboardType.Text
+                            keyboardType = if (isNumber) KeyboardType.NumberPassword else KeyboardType.Text
                         )
                     )
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountCreateScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountCreateScreen.kt
@@ -157,9 +157,8 @@ class AccountCreateScreen @Inject constructor(
             trailingIcon = {
                 AccountNumberGenerate(onAutoGenerateClick)
             },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
-            )
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
         )
     }
     @Composable
@@ -233,9 +232,8 @@ class AccountCreateScreen @Inject constructor(
             onValueChange = {
                 onValueChange(nowAccount.copy(phoneNumber = it))
             },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
-            ),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
             visualTransformation = VisualTransformation { phoneNumber ->
                 getPhoneNumberTransfomred(phoneNumber.text)
             }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/account/AccountDetailScreen.kt
@@ -248,9 +248,8 @@ class AccountDetailScreen @Inject constructor(
             onValueChange = {
                 onRecordChange(newRecord.copy(difference = it))
             },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
-            )
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
         )
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/menu/MenuScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/menu/MenuScreen.kt
@@ -150,7 +150,8 @@ class MenuScreen @Inject constructor(
                     value = newMenu.price,
                     onValueChange = { onMenuChanged(newMenu.copy(price = it)) },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
                 )
 
                 Spacer(modifier = Modifier.size(16.dp))

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/phone/table/TableScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -498,7 +500,9 @@ class TableScreen @Inject constructor(
             TextField(
                 value = pointUse.accountNumber,
                 onValueChange = onAccountNumberChange,
-                label = { Text(text = stringResource(R.string.account_number)) }
+                label = { Text(text = stringResource(R.string.account_number)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
             )
             TextField(
                 value = pointUse.userName,

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountCreateScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountCreateScreen.kt
@@ -157,9 +157,8 @@ class AccountCreateScreen @Inject constructor(
             trailingIcon = {
                 AccountNumberGenerate(onAutoGenerateClick)
             },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
-            )
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
         )
     }
     @Composable
@@ -233,9 +232,8 @@ class AccountCreateScreen @Inject constructor(
             onValueChange = {
                 onValueChange(nowAccount.copy(phoneNumber = it))
             },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
-            ),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
             visualTransformation = VisualTransformation { phoneNumber ->
                 getPhoneNumberTransfomred(phoneNumber.text)
             }

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountDetailScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/account/AccountDetailScreen.kt
@@ -248,9 +248,8 @@ class AccountDetailScreen @Inject constructor(
             onValueChange = {
                 onRecordChange(newRecord.copy(difference = it))
             },
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
-            )
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
         )
     }
 

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/menu/MenuScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/menu/MenuScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
@@ -28,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dirtfy.ppp.R
@@ -152,7 +154,9 @@ class MenuScreen @Inject constructor(
                             value = newMenu.price,
                             onValueChange = {
                                 onMenuChanged(newMenu.copy(price = it))
-                            }
+                            },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
                         )
                         Spacer(modifier = Modifier.size(10.dp))
                         Button(

--- a/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
+++ b/app/src/main/java/com/dirtfy/ppp/ui/view/tablet/table/TableScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -503,7 +505,9 @@ class TableScreen @Inject constructor(
             TextField(
                 value = pointUse.accountNumber,
                 onValueChange = onAccountNumberChange,
-                label = { Text(text = stringResource(R.string.account_number)) }
+                label = { Text(text = stringResource(R.string.account_number)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
             )
             TextField(
                 value = pointUse.userName,


### PR DESCRIPTION
TextField의 keyboardOptions 옵션에 KeyboardType.NumberPassword를 사용하여 다음 이슈를 해결했습니다.

- #99 
대시 문자를 입력하지 못하도록 막음
- #100 
toInt() 함수가 작동 할 수 없을 만한 문자를 입력하지 못하도록 막음

참고) KeyboardType.NumberPassword 키보드는 다음과 같음.

![Screenshot_20241212_171831_PPP.jpg](https://github.com/user-attachments/assets/8d6b232a-baed-4a0e-990f-5c36d92bef7b)

여러 줄 입력 가능하도록 해 놓으면 완료 버튼 부분이 줄바꿈 키로 표시되기 때문에 
singleLine = true 옵션도 적용함.
